### PR TITLE
support multiple set-cookie headers in response

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -60,7 +60,11 @@ const getRequestListener = (fetchCallback: FetchCallback) => {
     const contentType = res.headers.get('content-type') || ''
 
     for (const [k, v] of res.headers) {
-      outgoing.setHeader(k, v)
+      if (k === 'set-cookie') {
+        outgoing.setHeader(k, res.headers.getAll(k))
+      } else {
+        outgoing.setHeader(k, v)
+      }
     }
     outgoing.statusCode = res.status
 


### PR DESCRIPTION
Fixes and edge case with multiple set-cookie headers in a single Response

- multiple `set-cookie` headers in a single `Response` is valid
- comma delimited `set-cookie` values in a single header are invalid (or rather they will not be picked up and set by the browser)
- the res.headers Iterator returns the equivalent of `res.headers.get('set-cookie')` for the value, which is a comma delimited string (and thus invalid)
- this fix will use `res.headers.getAll('set-cookie')` which returns an array of strings which is a valid value in `response.setHeader` https://nodejs.org/docs/latest-v18.x/api/http.html#responsesetheadername-value