### PR TITLE
fix if statement bug in server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -46,7 +46,7 @@ const getRequestListener = (fetchCallback: FetchCallback) => {
       headers: headerRecord,
     } as RequestInit
 
-    if (!(method === ('GET' || 'HEAD'))) {
+    if (!(method === 'GET' || method === 'HEAD')) {
       const buffers = []
       for await (const chunk of incoming) {
         buffers.push(chunk)


### PR DESCRIPTION
This change fixes a bug with the handling of `HEAD` requests.

Previously we would never match on a `HEAD` request and thus incorrectly create a body to the request, which would throw an uncaught error