### PR TITLE
fix bug with encoded responses

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -64,6 +64,7 @@ const getRequestListener = (fetchCallback: FetchCallback) => {
     }
 
     const contentType = res.headers.get('content-type') || ''
+    const contentEncoding = res.headers.get('content-encoding')
 
     for (const [k, v] of res.headers) {
       if (k === 'set-cookie') {
@@ -75,9 +76,9 @@ const getRequestListener = (fetchCallback: FetchCallback) => {
     outgoing.statusCode = res.status
 
     if (res.body) {
-      if (contentType.startsWith('text')) {
+      if (!contentEncoding && contentType.startsWith('text')) {
         outgoing.end(await res.text())
-      } else if (contentType.startsWith('application/json')) {
+      } else if (!contentEncoding && contentType.startsWith('application/json')) {
         outgoing.end(await res.text())
       } else {
         await writeReadableStreamToWritable(res.body, outgoing)


### PR DESCRIPTION
This change fixes how we write out a response body so that we can support encoded responses

Previously we would cause a content encoding error by calling `res.text()` on responses even if they are encoded (`br`,`gzip` etc). Now we check if the response has the `content-encoding` header and use the read/write stream instead if it does.