### PR TITLE
Update serve-static.ts

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -69,7 +69,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Handler
 
                c.header('Content-Range', `bytes ${start}-${end}/${stat.size}`);
 
-               c.status(206);
+               c.status(range ? 206 : 200);
 
                const body = new ReadableStream({
 

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -1,4 +1,4 @@
-import type { Handler } from 'hono'
+import type { MiddlewareHandler } from 'hono'
 import { createReadStream, existsSync, lstatSync } from 'fs'
 import { getFilePath } from 'hono/utils/filepath'
 import { getMimeType } from 'hono/utils/mime'
@@ -9,7 +9,7 @@ export type ServeStaticOptions = {
   index?: string // default is 'index.html'
 }
 
-export const serveStatic = (options: ServeStaticOptions = { root: '' }): Handler => {
+export const serveStatic = (options: ServeStaticOptions = { root: '' }): MiddlewareHandler => {
   return async (c, next) => {
     // Do nothing if Response is already set
     if (c.finalized) return next()

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -19,7 +19,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Handler
           const url = new URL(c.req.url);
 
           let path = getFilePath({
-               filename: options.path ?? url.pathname,
+               filename: options.path ?? decodeURIComponent(url.pathname),
                root: options.root,
                defaultDocument: options.index ?? 'index.html',
           })

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -1,105 +1,90 @@
-import type { Next, Context, Handler } from 'hono'
+import type { Handler } from 'hono'
 import { createReadStream, existsSync, lstatSync } from 'fs'
 import { getFilePath } from 'hono/utils/filepath'
 import { getMimeType } from 'hono/utils/mime'
 
 export type ServeStaticOptions = {
-     root?: string
-     path?: string
-     index?: string // default is 'index.html'
-};
+  root?: string
+  path?: string
+  index?: string // default is 'index.html'
+}
 
 export const serveStatic = (options: ServeStaticOptions = { root: '' }): Handler => {
+  return async (c, next) => {
+    // Do nothing if Response is already set
+    if (c.finalized) return next()
 
-     return async (c: Context, next: Next) => {
+    const url = new URL(c.req.url)
 
-          // Do nothing if Response is already set
-          if (c.finalized) return next()
+    let path = getFilePath({
+      filename: options.path ?? decodeURIComponent(url.pathname),
+      root: options.root,
+      defaultDocument: options.index ?? 'index.html',
+    })
 
-          const url = new URL(c.req.url);
+    path = `./${path}`
 
-          let path = getFilePath({
-               filename: options.path ?? decodeURIComponent(url.pathname),
-               root: options.root,
-               defaultDocument: options.index ?? 'index.html',
+    if (existsSync(path)) {
+      const mimeType = getMimeType(path)
+
+      const stat = lstatSync(path)
+
+      if (mimeType) {
+        c.header('Content-Type', mimeType)
+      }
+
+      c.header('Accept-Ranges', 'bytes')
+
+      c.header('Date', stat.birthtime.toUTCString())
+
+      if (c.req.method == 'HEAD' || c.req.method == 'OPTIONS') {
+        c.header('Content-Length', stat.size.toString())
+
+        c.status(200)
+
+        return c.body(null)
+      }
+
+      const range = c.req.headers.get('range')
+
+      let start = 0
+      let end = stat.size - 1
+
+      if (range) {
+        const parts = range.replace(/bytes=/, '').split('-')
+        start = parseInt(parts[0], 10)
+        end = parts[1] ? parseInt(parts[1], 10) : end
+      }
+
+      const chunksize = end - start + 1
+
+      const stream = createReadStream(path, { start, end })
+
+      c.header('Content-Length', chunksize.toString())
+
+      c.header('Content-Range', `bytes ${start}-${end}/${stat.size}`)
+
+      c.status(range ? 206 : 200)
+
+      const body = new ReadableStream({
+        start(controller) {
+          stream.on('data', (chunk) => {
+            controller.enqueue(chunk)
           })
 
-          path = `./${path}`;
+          stream.on('end', () => {
+            controller.close()
+          })
+        },
 
-          if (existsSync(path)) {
+        cancel() {
+          stream.destroy()
+        },
+      })
 
-               const mimeType = getMimeType(path)
+      return c.body(body)
+    }
 
-               const stat = lstatSync(path);
-
-               if (mimeType) {
-
-                    c.header('Content-Type', mimeType)
-               }
-
-               c.header('Accept-Ranges', 'bytes');
-
-               c.header("Date", stat.birthtime.toUTCString())
-
-               if (c.req.method == 'HEAD' || c.req.method == 'OPTIONS') {
-
-                    c.header('Content-Length', stat.size.toString());
-
-                    c.status(200);
-
-                    return c.body(null);
-               }
-
-               const range = c.req.headers.get('range');
-
-               let start = 0;
-               let end = stat.size - 1;
-
-               if (range) {
-                    const parts = range.replace(/bytes=/, "").split("-");
-                    start = parseInt(parts[0], 10);
-                    end = parts[1] ? parseInt(parts[1], 10) : end;
-               }
-
-               const chunksize = (end - start) + 1;
-
-               const stream = createReadStream(path, { start, end });
-
-               c.header('Content-Length', chunksize.toString());
-
-               c.header('Content-Range', `bytes ${start}-${end}/${stat.size}`);
-
-               c.status(range ? 206 : 200);
-
-               const body = new ReadableStream({
-
-                    start(controller) {
-
-                         stream.on('data', (chunk) => {
-
-                              controller.enqueue(chunk);
-
-                         });
-
-                         stream.on('end', () => {
-
-                              controller.close();
-
-                         });
-
-                    },
-
-                    cancel() {
-
-                         stream.destroy();
-
-                    },
-
-               });
-
-               return c.body(body);
-          }
-
-          return next();
-     }
+    return next()
+  }
 }

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -1,44 +1,105 @@
-import type { Next } from 'hono'
-import { Context } from 'hono'
-import { existsSync, readFileSync } from 'fs'
+import type { Next, Context, Handler } from 'hono'
+import { createReadStream, existsSync, lstatSync } from 'fs'
 import { getFilePath } from 'hono/utils/filepath'
 import { getMimeType } from 'hono/utils/mime'
 
 export type ServeStaticOptions = {
-  root?: string
-  path?: string
-  index?: string // default is 'index.html'
-}
+     root?: string
+     path?: string
+     index?: string // default is 'index.html'
+};
 
-export const serveStatic = (options: ServeStaticOptions = { root: '' }) => {
-  return async (c: Context, next: Next): Promise<Response | undefined> => {
-    // Do nothing if Response is already set
-    if (c.finalized) {
-      await next()
-    }
-    const url = new URL(c.req.url)
+export const serveStatic = (options: ServeStaticOptions = { root: '' }): Handler => {
 
-    let path = getFilePath({
-      filename: options.path ?? url.pathname,
-      root: options.root,
-      defaultDocument: options.index ?? 'index.html',
-    })
-    path = `./${path}`
+     return async (c: Context, next: Next) => {
 
-    if (existsSync(path)) {
-      const content = readFileSync(path)
-      if (content) {
-        const mimeType = getMimeType(path)
-        if (mimeType) {
-          c.header('Content-Type', mimeType)
-        }
-        // Return Response object
-        return c.body(content)
-      }
-    }
+          // Do nothing if Response is already set
+          if (c.finalized) return next()
 
-    console.warn(`Static file: ${path} is not found`)
-    await next()
-    return
-  }
+          const url = new URL(c.req.url);
+
+          let path = getFilePath({
+               filename: options.path ?? url.pathname,
+               root: options.root,
+               defaultDocument: options.index ?? 'index.html',
+          })
+
+          path = `./${path}`;
+
+          if (existsSync(path)) {
+
+               const mimeType = getMimeType(path)
+
+               const stat = lstatSync(path);
+
+               if (mimeType) {
+
+                    c.header('Content-Type', mimeType)
+               }
+
+               c.header('Accept-Ranges', 'bytes');
+
+               c.header("Date", stat.birthtime.toUTCString())
+
+               if (c.req.method == 'HEAD' || c.req.method == 'OPTIONS') {
+
+                    c.header('Content-Length', stat.size.toString());
+
+                    c.status(200);
+
+                    return c.body(null);
+               }
+
+               const range = c.req.headers.get('range');
+
+               let start = 0;
+               let end = stat.size - 1;
+
+               if (range) {
+                    const parts = range.replace(/bytes=/, "").split("-");
+                    start = parseInt(parts[0], 10);
+                    end = parts[1] ? parseInt(parts[1], 10) : end;
+               }
+
+               const chunksize = (end - start) + 1;
+
+               const stream = createReadStream(path, { start, end });
+
+               c.header('Content-Length', chunksize.toString());
+
+               c.header('Content-Range', `bytes ${start}-${end}/${stat.size}`);
+
+               c.status(206);
+
+               const body = new ReadableStream({
+
+                    start(controller) {
+
+                         stream.on('data', (chunk) => {
+
+                              controller.enqueue(chunk);
+
+                         });
+
+                         stream.on('end', () => {
+
+                              controller.close();
+
+                         });
+
+                    },
+
+                    cancel() {
+
+                         stream.destroy();
+
+                    },
+
+               });
+
+               return c.body(body);
+          }
+
+          return next();
+     }
 }

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -55,4 +55,23 @@ describe('Serve Static Middleware', () => {
     expect(res.headers['content-type']).toBe('text/plain; charset=UTF-8')
     expect(res.text).toBe('404 Not Found')
   })
+
+  it('Should return correct headers and data with range headers', async () => {
+    let res = await request(server).get('/static/plain.txt').set('range', '0-9')
+    expect(res.status).toBe(206)
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8')
+    expect(res.headers['content-length']).toBe('10')
+    expect(res.headers['content-range']).toBe('bytes 0-9/17')
+    expect(res.text.length).toBe(10)
+    expect(res.text).toBe('This is pl')
+
+    res = await request(server).get('/static/plain.txt').set('range', '10-16')
+    expect(res.status).toBe(206)
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8')
+    expect(res.headers['content-length']).toBe('7')
+    expect(res.headers['content-range']).toBe('bytes 10-16/17')
+    expect(res.text.length).toBe(7)
+    expect(res.text).toBe('ain.txt')
+  })
 })
+


### PR DESCRIPTION
# Mistakes from the original code.


https://github.com/honojs/node-server/blob/a685db90ebb91164106ccc9a65759cda9df4bbb7/src/serve-static.ts#L29
This will load the whole file into memory.
If you attempt to serve an MP4 that is `1GB` in size, `1GB` will be loaded into memory. As a result, if you attempt to load that file 10 times and your server or computer only has `10GB` of RAM, your memory will run out and your client will fail.
Use streams and range headers as a solution.
See [Range headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) for more information.

-----

https://github.com/honojs/node-server/blob/a685db90ebb91164106ccc9a65759cda9df4bbb7/src/serve-static.ts#L16-L18
The request will go on to the next handler if it is finished, but the code at the bottom will continue to execute as if the request was never concluded in the first place.

-----

https://github.com/honojs/node-server/blob/a685db90ebb91164106ccc9a65759cda9df4bbb7/src/serve-static.ts#L31
This issue has nothing to do with this repo, but it was missing a LOT of mimetypes, like MP4 videos, gltf, glb 3d files etc, i made a separate pull request to its repo at https://github.com/honojs/hono/pull/827
