### PR TITLE
global.crypto fix for Node 19.0

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -58,7 +58,9 @@ export function installGlobals() {
   global.ReadableStream = NodeReadableStream
   global.WritableStream = NodeWritableStream
 
-  global.crypto = crypto as Crypto
+  if (typeof global.crypto === "undefined") {
+    global.crypto = crypto as Crypto
+  }
 }
 
 /**


### PR DESCRIPTION
With Node.js 19.0, the Web Crypto API is now accessible directly from the global object. global.crypto is not writable so trying to assign to it crashes the program. This is a simple fix for it.