### PR TITLE
Must use relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ import { serveStatic } from '@hono/node-server/serve-static'
 app.use('/static/*', serveStatic({ root: './' }))
 ```
 
+Note that `root` must be *relative* to the current working directory - absolute paths are not supported.
+
 ## Related projects
 
 - Hono - <https://honojs.dev>

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -5,6 +5,9 @@ import { getFilePath } from 'hono/utils/filepath'
 import { getMimeType } from 'hono/utils/mime'
 
 export type ServeStaticOptions = {
+  /**
+   * Root path, relative to current working directory. (absolute paths are not supported)
+   */
   root?: string
   path?: string
   index?: string // default is 'index.html'


### PR DESCRIPTION
Added documentation for `path`, which appears to require relative paths.

It was not obvious for someone porting a project with absolute paths from Express - the error messages were confusing:

```
Static file: ./home/mindplay/workspace/try-hono/public/index.css is not found
```

At a glance, it looks like the file exists - but the `.` at the beginning of course makes it relative to the current working directory.

It's not clear to me whether this is intentional, for platform portability perhaps? Most other Node servers would accept an absolute path - and this middleware only works on Node. But you might want relative paths in Hono projects as a convention?

If this is **not** intentional, you should reject this PR!
