### PR TITLE
fix: add TransformStream to global and re-implement stream pipe

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -2,6 +2,9 @@ import crypto from 'node:crypto'
 import {
   ReadableStream as NodeReadableStream,
   WritableStream as NodeWritableStream,
+  TransformStream as NodeTransformStream,
+  TextDecoderStream as NodeTextDecoderStream,
+  TextEncoderStream as NodeTextEncoderStream,
 } from '@remix-run/web-stream'
 
 import { atob, btoa } from './base64'
@@ -36,6 +39,9 @@ declare global {
 
       ReadableStream: typeof ReadableStream
       WritableStream: typeof WritableStream
+      TransformStream: typeof TransformStream
+      TextDecoderStream: typeof TextDecoderStream
+      TextEncoderStream: typeof TextEncoderStream
 
       crypto: Crypto
     }
@@ -57,6 +63,9 @@ export function installGlobals() {
 
   global.ReadableStream = NodeReadableStream
   global.WritableStream = NodeWritableStream
+  global.TransformStream = NodeTransformStream
+  global.TextDecoderStream = NodeTextDecoderStream
+  global.TextEncoderStream = NodeTextEncoderStream
 
   if (typeof global.crypto === 'undefined') {
     // If crypto.subtle is undefined, we're in a Node.js v16 environment

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -83,7 +83,7 @@ export function nodeReadableToWebReadableStream(readable: Readable) {
       chunk = new Uint8Array(chunk)
     }
     controller.enqueue(chunk)
-    if (controller.desiredSize && controller.desiredSize <= 0) {
+    if (controller.desiredSize !== null && controller.desiredSize <= 0) {
       readable.pause()
     }
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,27 +1,67 @@
-import type { Writable } from 'node:stream'
+import { Writable, Readable } from 'node:stream'
+import { pipeline } from 'node:stream'
+import { promisify } from 'node:util'
 
-export async function writeReadableStreamToWritable(stream: ReadableStream, writable: Writable) {
+const pipelinePromise = promisify(pipeline)
+
+/** pipeline will assure the backpressure and reduce huge memory usage */
+export async function writeReadableStreamToWritable(
+  stream: ReadableStream,
+  writable: Writable
+) {
+  const readable = webReadableStreamToNodeReadable(stream)
+  return pipelinePromise(readable, writable)
+}
+
+/** This implementation use nodejs Readable::fromWeb as references */
+export function webReadableStreamToNodeReadable(
+  stream: ReadableStream
+): Readable {
   const reader = stream.getReader()
+  let closed = false
 
-  function onClose() {
-    reader.cancel(new Error('Response writer closed'))
-  }
-
-  writable.once('close', onClose)
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read()
-
-      if (done) {
-        writable.end()
-        return
+  const readable = new Readable({
+    read() {
+      reader
+        .read()
+        .then(({ done, value }) => {
+          if (done) {
+            this.push(null)
+          } else {
+            this.push(value)
+          }
+        })
+        .catch(e => {
+          readable.destroy(e)
+        })
+    },
+    destroy(error, callback) {
+      const done = () => {
+        try {
+          callback(error)
+        } catch (err: unknown) {
+          process.nextTick(() => {
+            throw err
+          })
+        }
       }
 
-      writable.write(value)
+      if (!closed) {
+        reader.cancel(error).then(done, done)
+        return
+      }
+      done()
+    },
+  })
+
+  reader.closed.then(
+    () => {
+      closed = true
+    },
+    error => {
+      readable.destroy(error)
     }
-  } finally {
-    writable.off('close', onClose)
-    reader.releaseLock()
-  }
+  )
+
+  return readable
 }


### PR DESCRIPTION
- Rewrite the implementation of `Stream Pipe`, taking inspiration from nodejs' `stream.Readable.fromWeb`, which offers better support for backpressure and highWatermark option.

- Additionally, TransformStream has been added to globals.