### PR TITLE
Fix broken built-in middleware link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ serve({
 ## Middleware
 
 Most built-in middleware also works with Node.js.
-Read [the documentation](https://honojs.dev/docs/builtin-middleware/) and use the Middleware of your liking.
+Read [the documentation](https://hono.dev/middleware/builtin/basic-auth) and use the Middleware of your liking.
 
 ```ts
 import { serve } from '@hono/node-server'


### PR DESCRIPTION
the previous link targeted a category/grouping page which no longer exists, so instead target the top-most document within the category it used to link to