### PR TITLE
Refactor imports to type imports

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -1,8 +1,8 @@
-import { IncomingMessage, ServerResponse } from 'node:http'
+import type { IncomingMessage, ServerResponse } from 'node:http'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
-import { FetchCallback } from './types'
+import type { FetchCallback } from './types'
 import './globals'
 
 export const getRequestListener = (fetchCallback: FetchCallback) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
-import { createServer as createServerHTTP, Server } from 'node:http'
-import { Options } from './types'
-import { getRequestListener } from './listener'
+import { createServer as createServerHTTP, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
+import type { Options } from './types'
+import { getRequestListener } from './listener'
 
 export const createAdaptorServer = (options: Options): Server => {
   const fetchCallback = options.fetch


### PR DESCRIPTION
`type` imports were used in some places,  but not all