### PR TITLE
support absolute root path for serveStatic

### DIFF
--- a/src/getFilePathforAbsRoot.test.ts
+++ b/src/getFilePathforAbsRoot.test.ts
@@ -1,0 +1,8 @@
+import { getFilePathforAbsRoot } from './getFilePathforAbsRoot'
+
+describe('getFilePathforAbsRoot', () => {
+  it('Should return file path correctly', async () => {
+    expect(getFilePathforAbsRoot({ filename: 'foo', root: '/bar' })).toBe('/bar/foo/index.html')
+    expect(getFilePathforAbsRoot({ filename: 'foo.txt', root: '/bar' })).toBe('/bar/foo.txt')
+  })
+})

--- a/src/getFilePathforAbsRoot.ts
+++ b/src/getFilePathforAbsRoot.ts
@@ -1,0 +1,23 @@
+import { getFilePath } from 'hono/utils/filepath'
+
+/**
+ * wrapper for getFilePath, with absolute root path
+ */
+export function getFilePathforAbsRoot(options: {
+  root: string
+  filename: string
+  defaultDocument?: string
+}) {
+  if (!options.root.startsWith('/')) {
+    throw new Error('root must be absolute path')
+  }
+
+  const path = getFilePath({
+    filename: options.filename,
+    defaultDocument: options.defaultDocument,
+  })
+  if (!path) return undefined
+
+  const root = options.root + (options.root?.endsWith('/') ? '' : '/')
+  return root + path
+}

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareHandler } from 'hono'
 import { ReadStream, createReadStream, existsSync, lstatSync } from 'fs'
 import { getFilePath } from 'hono/utils/filepath'
+import { getFilePathforAbsRoot } from './getFilePathforAbsRoot'
 import { getMimeType } from 'hono/utils/mime'
 
 export type ServeStaticOptions = {
@@ -38,27 +39,33 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
 
     const url = new URL(c.req.url)
 
-    const filename = options.path ?? decodeURIComponent(url.pathname)
-    let path = getFilePath({
-      filename: options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename,
-      root: options.root,
-      defaultDocument: options.index ?? 'index.html',
-    })
+    const path = options.path ?? decodeURIComponent(url.pathname)
+    const filename = options.rewriteRequestPath?.(path) ?? path
+    const defaultDocument = options.index ?? 'index.html'
 
-    if (!path) return next()
+    const filePath = options.root?.startsWith('/')
+      ? getFilePathforAbsRoot({
+          filename,
+          root: options.root,
+          defaultDocument,
+        })
+      : './' +
+        getFilePath({
+          filename,
+          root: options.root,
+          defaultDocument,
+        })
 
-    path = `./${path}`
-
-    if (!existsSync(path)) {
+    if (!filePath || !existsSync(filePath)) {
       return next()
     }
 
-    const mimeType = getMimeType(path)
+    const mimeType = getMimeType(filePath)
     if (mimeType) {
       c.header('Content-Type', mimeType)
     }
 
-    const stat = lstatSync(path)
+    const stat = lstatSync(filePath)
     const size = stat.size
 
     if (c.req.method == 'HEAD' || c.req.method == 'OPTIONS') {
@@ -71,7 +78,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
 
     if (!range) {
       c.header('Content-Length', size.toString())
-      return c.body(createStreamBody(createReadStream(path)), 200)
+      return c.body(createStreamBody(createReadStream(filePath)), 200)
     }
 
     c.header('Accept-Ranges', 'bytes')
@@ -88,7 +95,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
     }
 
     const chunksize = end - start + 1
-    const stream = createReadStream(path, { start, end })
+    const stream = createReadStream(filePath, { start, end })
 
     c.header('Content-Length', chunksize.toString())
     c.header('Content-Range', `bytes ${start}-${end}/${stat.size}`)

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -6,7 +6,7 @@ import { getMimeType } from 'hono/utils/mime'
 
 export type ServeStaticOptions = {
   /**
-   * Root path, relative to current working directory. (absolute paths are not supported)
+   * Root path, relative to current working directory or absolte path.
    */
   root?: string
   path?: string


### PR DESCRIPTION
Currently, serveStatic's options.root doesn't support absolute paths. 
It appears that the getFilePath utility function isn't designed for this case. 
I've created a small wrapper to address this issue.
