### PR TITLE
fix: don't `destroy` if `pipeline` throws an error

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -89,9 +89,6 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
       } catch (e: unknown) {
         // try to catch any error, to avoid crash
         console.error(e)
-        const err = e instanceof Error ? e : new Error('unknown error', { cause: e })
-        // destroy error must accept an instance of Error
-        outgoing.destroy(err)
       }
     } else {
       outgoing.end()

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -87,8 +87,10 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
           outgoing.end(text)
         }
       } catch (e: unknown) {
-        const err = e instanceof Error ? e : new Error('unknown error', { cause: e })
-        if (err.name === 'ERR_STREAM_PREMATURE_CLOSE') {
+        const err = (e instanceof Error ? e : new Error('unknown error', { cause: e })) as Error & {
+          code: string
+        }
+        if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
           console.info('The user aborted a request.')
         } else {
           console.error(e)

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -87,8 +87,13 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
           outgoing.end(text)
         }
       } catch (e: unknown) {
-        // try to catch any error, to avoid crash
-        console.error(e)
+        const err = e instanceof Error ? e : new Error('unknown error', { cause: e })
+        if (err.name === 'ERR_STREAM_PREMATURE_CLOSE') {
+          console.info('The user aborted a request.')
+        } else {
+          console.error(e)
+          outgoing.destroy(err)
+        }
       }
     } else {
       outgoing.end()


### PR DESCRIPTION
Fix #73 https://github.com/honojs/hono/issues/1253