### PR TITLE
perf: polish `listener.ts`

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -75,6 +75,7 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
           resHeaderRecord['transfer-encoding'] ||
           resHeaderRecord['content-encoding'] ||
           resHeaderRecord['content-length'] ||
+          // nginx buffering variant
           regBuffer.test(resHeaderRecord['x-accel-buffering']) ||
           !regContentType.test(resHeaderRecord['content-type'])
         ) {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -6,6 +6,9 @@ import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
 import type { FetchCallback } from './types'
 import './globals'
 
+const regBuffer = /^no$/i
+const regContentType = /^(application\/json\b|text\/(?!event-stream\b))/i
+
 export const getRequestListener = (fetchCallback: FetchCallback) => {
   return async (
     incoming: IncomingMessage | Http2ServerRequest,
@@ -46,14 +49,9 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
       }
     }
 
-    const contentType = res.headers.get('content-type') || ''
-    // nginx buffering variant
-    const buffering = res.headers.get('x-accel-buffering') || ''
-    const contentEncoding = res.headers.get('content-encoding')
-    const contentLength = res.headers.get('content-length')
-    const transferEncoding = res.headers.get('transfer-encoding')
-
+    const resHeaderRecord: Record<string, string> = {}
     for (const [k, v] of res.headers) {
+      resHeaderRecord[k] = v
       if (k === 'set-cookie') {
         // node native Headers.prototype has getSetCookie method
         outgoing.setHeader(k, (res.headers as any).getSetCookie(k))
@@ -74,11 +72,11 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
          * we assume that the response should be streamed.
          */
         if (
-          contentEncoding ||
-          transferEncoding ||
-          contentLength ||
-          /^no$/i.test(buffering) ||
-          !/^(application\/json\b|text\/(?!event-stream\b))/i.test(contentType)
+          resHeaderRecord['transfer-encoding'] ||
+          resHeaderRecord['content-encoding'] ||
+          resHeaderRecord['content-length'] ||
+          regBuffer.test(resHeaderRecord['x-accel-buffering']) ||
+          !regContentType.test(resHeaderRecord['content-type'])
         ) {
           await pipeline(Readable.fromWeb(res.body as NodeReadableStream), outgoing)
         } else {


### PR DESCRIPTION
For performance improvement:

1. Cache regexp objects (though I think it's not very effective).
2. Avoid using `res.headers.get()`.

The result on Node.js 20:

<img width="1196" alt="Screenshot 2023-11-12 at 1 03 14" src="https://github.com/honojs/node-server/assets/10682/c8b641b6-e2a4-45b2-b8b7-afe20e3460d2">

