### PR TITLE
perf: small improvements

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -80,7 +80,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
     let start = 0
     let end = stat.size - 1
 
-    const parts = range.replace(/bytes=/, '').split('-')
+    const parts = range.replace(/bytes=/, '').split('-', 2)
     start = parseInt(parts[0], 10)
     end = parts[1] ? parseInt(parts[1], 10) : end
     if (size < end - start + 1) {

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -77,11 +77,9 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
     c.header('Accept-Ranges', 'bytes')
     c.header('Date', stat.birthtime.toUTCString())
 
-    let end = stat.size - 1
-
     const parts = range.replace(/bytes=/, '').split('-', 2)
     const start = parts[0] ? parseInt(parts[0], 10) : 0
-    end = parts[1] ? parseInt(parts[1], 10) : end
+    let end = parts[1] ? parseInt(parts[1], 10) : stat.size - 1
     if (size < end - start + 1) {
       end = size - 1
     }

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -77,11 +77,10 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
     c.header('Accept-Ranges', 'bytes')
     c.header('Date', stat.birthtime.toUTCString())
 
-    let start = 0
     let end = stat.size - 1
 
     const parts = range.replace(/bytes=/, '').split('-', 2)
-    start = parseInt(parts[0], 10)
+    const start = parts[0] ? parseInt(parts[0], 10) : 0
     end = parts[1] ? parseInt(parts[1], 10) : end
     if (size < end - start + 1) {
       end = size - 1

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,12 +3,11 @@ import type { Writable } from 'node:stream'
 export function writeFromReadableStream(stream: ReadableStream<Uint8Array>, writable: Writable) {
   if (stream.locked) {
     throw new TypeError('ReadableStream is locked.')
-  }
-  const reader = stream.getReader()
-  if (writable.destroyed) {
-    reader.cancel()
+  } else if (writable.destroyed) {
+    stream.cancel();
     return
   }
+  const reader = stream.getReader()
   writable.on('drain', onDrain)
   writable.on('close', cancel)
   writable.on('error', cancel)


### PR DESCRIPTION
I think these changes will bring small performance improvements because :
- the `split` function call will stop when we've retrieved the 2 elements we're using. It also prevents people from putting unnecessary elements in the `Range` header, which can affect performance.
- Reduce multiple assignments on `start` and `end` variables
- Call the `ReadableStream.getReader` function only if the `Writable` is not destroyed.