### PR TITLE
refactor: set content-length as number with `outgoing.writeHead()`

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -35,7 +35,7 @@ const responseViaCache = (
 ): undefined | Promise<undefined> => {
   const [status, body, header] = (res as any)[cacheKey]
   if (typeof body === 'string') {
-    header['content-length'] ||= '' + Buffer.byteLength(body)
+    header['Content-Length'] = Buffer.byteLength(body)
     outgoing.writeHead(status, header)
     outgoing.end(body)
   } else {


### PR DESCRIPTION
It would be better to use `number`, even if it may not affect performance.

> Content-Length is read in bytes, not characters. Use [Buffer.byteLength()](https://github.com/nodejs/node/blob/main/doc/api/buffer.md#static-method-bufferbytelengthstring-encoding) to determine the length of the body in bytes. Node.js will check whether Content-Length and the length of the body which has been transmitted are equal or not.

https://github.com/nodejs/node/blob/main/doc/api/http.md#responsewriteheadstatuscode-statusmessage-headers