### PR TITLE
fix: Nested `new` call problem

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -6,13 +6,13 @@ import { buildOutgoingHttpHeaders } from './utils'
 const responseCache = Symbol('responseCache')
 export const cacheKey = Symbol('cache')
 
-export const globalResponse = global.Response
+export const GlobalResponse = global.Response
 export class Response {
   #body?: BodyInit | null
   #init?: ResponseInit;
 
   // @ts-ignore
-  private get cache(): typeof globalResponse {
+  private get cache(): typeof GlobalResponse {
     delete (this as any)[cacheKey]
     return ((this as any)[responseCache] ||= new globalResponse(this.#body, this.#init))
   }
@@ -59,8 +59,8 @@ export class Response {
     },
   })
 })
-Object.setPrototypeOf(Response, globalResponse)
-Object.setPrototypeOf(Response.prototype, globalResponse.prototype)
+Object.setPrototypeOf(Response, GlobalResponse)
+Object.setPrototypeOf(Response.prototype, GlobalResponse.prototype)
 Object.defineProperty(global, 'Response', {
   value: Response,
 })

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -54,5 +54,14 @@ describe('Response', () => {
 
     // support other class to extends from Response
     expect(new NextResponse()).toBeInstanceOf(Response)
+
+    const parentResponse = new Response('OK', {
+      headers: {
+        'content-type': 'application/json',
+      }
+    })
+    const childResponse = new Response('OK', parentResponse)
+    parentResponse.headers.delete('content-type')
+    expect(childResponse.headers.get('content-type')).toEqual('application/json')
   })
 })

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http'
 import { AddressInfo } from 'node:net'
-import { globalResponse } from '../src/response'
+import { GlobalResponse } from '../src/response'
 
 class NextResponse extends Response {}
 
@@ -33,7 +33,7 @@ describe('Response', () => {
     expect(Response.name).toEqual('Response')
 
     // response prototype chain not changed
-    expect(new Response()).toBeInstanceOf(globalResponse)
+    expect(new Response()).toBeInstanceOf(GlobalResponse)
 
     // `fetch()` and `Response` are not changed
     const fetchRes = await fetch(`http://localhost:${port}`)

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -477,3 +477,24 @@ describe('Hono compression', () => {
     expect(res.headers['content-encoding']).toMatch(/gzip/)
   })
 })
+
+
+describe('set child response to c.res', () => {
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    await next()
+    c.res = new Response('', c.res)
+    c.res.headers // If this is set, test fails
+  })
+
+  app.get('/json', async (c) => {
+    return c.json({})
+  })
+
+  it('Should return 200 response - GET /json', async () => {
+    const server = createAdaptorServer(app)
+    const res = await request(server).get('/json')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toMatch(/application\/json/)
+  })
+})


### PR DESCRIPTION
fixes #104

### Cause of the Problem

This is a bit of a detour, but the cause is that when `new Response(options)` was called in a nested manner, the `options` referred to the same object in memory as the parent and child.

So when we did `this.#res.headers.delete('content-type')` at the following location in hono, all `content-type`s of the parent and child were deleted and the `applicatioin/json` information was lost.

https://github.com/honojs/hono/blob/main/src/context.ts#L145

If the actual global.Response is passed to option when making a nested new call, the header is cloned in it process, so this problem is fixed.