### PR TITLE
fix: handle response that is not an instance of `Response`

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -25,6 +25,10 @@ const handleResponseError = (e: unknown, outgoing: ServerResponse | Http2ServerR
     console.info('The user aborted a request.')
   } else {
     console.error(e)
+    outgoing.headersSent
+      ? outgoing.writeHead(500)
+      : outgoing.writeHead(500, { 'Content-Type': 'text/plain' })
+    outgoing.end(`Error: ${err.message}`)
     outgoing.destroy(err)
   }
 }
@@ -53,6 +57,13 @@ const responseViaResponseObject = async (
 ) => {
   if (res instanceof Promise) {
     res = await res.catch(handleFetchError)
+  }
+  if (!(res instanceof Response)) {
+    return handleResponseError(
+      // @ts-expect-error the object must have `toString()`
+      new Error(`The response is not an instance of Response, but ${res.toString()}`),
+      outgoing
+    )
   }
   if (cacheKey in res) {
     try {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -25,9 +25,7 @@ const handleResponseError = (e: unknown, outgoing: ServerResponse | Http2ServerR
     console.info('The user aborted a request.')
   } else {
     console.error(e)
-    outgoing.headersSent
-      ? outgoing.writeHead(500)
-      : outgoing.writeHead(500, { 'Content-Type': 'text/plain' })
+    if (!outgoing.headersSent) outgoing.writeHead(500, { 'Content-Type': 'text/plain' })
     outgoing.end(`Error: ${err.message}`)
     outgoing.destroy(err)
   }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -24,6 +24,10 @@ describe('Basic', () => {
   app.delete('/posts/:id', (c) => {
     return c.text(`DELETE ${c.req.param('id')}`)
   })
+  // @ts-expect-error the response is string
+  app.get('/invalid', () => {
+    return '<h1>HTML</h1>'
+  })
 
   const server = createAdaptorServer(app)
 
@@ -57,6 +61,14 @@ describe('Basic', () => {
     const res = await request(server).delete('/posts/123')
     expect(res.status).toBe(200)
     expect(res.text).toBe('DELETE 123')
+  })
+
+  it('Should return 500 response - GET /invalid', async () => {
+    const res = await request(server).get('/invalid')
+    expect(res.status).toBe(500)
+    expect(res.headers['content-type']).toBe('text/plain')
+    // The error message might be changed.
+    expect(res.text).toBe('Error: The response is not an instance of Response, but <h1>HTML</h1>')
   })
 })
 
@@ -477,7 +489,6 @@ describe('Hono compression', () => {
     expect(res.headers['content-encoding']).toMatch(/gzip/)
   })
 })
-
 
 describe('set child response to c.res', () => {
   const app = new Hono()


### PR DESCRIPTION
Fixes #114

Handling of responses returned from applications that are not `Response` instances, returning a proper response.