### PR TITLE
feat: Forward Raw `IncomingMessage` and `ServerResponse` Via `Env`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { serve, createAdaptorServer } from './server'
 export { getRequestListener } from './listener'
+export type { HttpBindings, Http2Bindings } from './types'

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -115,7 +115,7 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
     const req = newRequest(incoming)
 
     try {
-      res = fetchCallback(req) as Response | Promise<Response>
+      res = fetchCallback(req, { incoming, outgoing }) as Response | Promise<Response>
       if (cacheKey in res) {
         // synchronous, cacheable response
         return responseViaCache(res as Response, outgoing)

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'node:
 import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import { newRequest } from './request'
 import { cacheKey } from './response'
-import type { FetchCallback } from './types'
+import type { FetchCallback, HttpBindings } from './types'
 import { writeFromReadableStream, buildOutgoingHttpHeaders } from './utils'
 import './globals'
 
@@ -115,7 +115,7 @@ export const getRequestListener = (fetchCallback: FetchCallback) => {
     const req = newRequest(incoming)
 
     try {
-      res = fetchCallback(req, { incoming, outgoing }) as Response | Promise<Response>
+      res = fetchCallback(req, { incoming, outgoing } as HttpBindings) as Response | Promise<Response>
       if (cacheKey in res) {
         // synchronous, cacheable response
         return responseViaCache(res as Response, outgoing)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,16 @@
-import type { createServer, Server, ServerOptions as HttpServerOptions } from 'node:http'
+import type {
+  createServer,
+  IncomingMessage,
+  Server,
+  ServerOptions as HttpServerOptions,
+  ServerResponse as HttpServerResponse,
+} from 'node:http'
 import type {
   createSecureServer as createSecureHttp2Server,
   createServer as createHttp2Server,
+  Http2ServerRequest,
   Http2Server,
+  Http2ServerResponse,
   Http2SecureServer,
   SecureServerOptions as SecureHttp2ServerOptions,
   ServerOptions as Http2ServerOptions,
@@ -11,9 +19,18 @@ import type {
   createServer as createHttpsServer,
   ServerOptions as HttpsServerOptions,
 } from 'node:https'
-import type { Hono } from 'hono'
 
-export type FetchCallback = typeof Hono['prototype']['fetch']
+export type HttpBindings = {
+  incoming: IncomingMessage
+  outgoing: HttpServerResponse
+}
+
+export type Http2Bindings = {
+  incoming: Http2ServerRequest
+  outgoing: Http2ServerResponse
+}
+
+export type FetchCallback = (request: Request, env: HttpBindings | Http2Bindings) => Promise<unknown> | unknown
 
 export type NextHandlerOption = {
   fetch: FetchCallback

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,9 @@ import type {
   createServer as createHttpsServer,
   ServerOptions as HttpsServerOptions,
 } from 'node:https'
+import type { Hono } from 'hono'
 
-export type FetchCallback = (request: Request) => Promise<unknown> | unknown
+export type FetchCallback = typeof Hono['prototype']['fetch']
 
 export type NextHandlerOption = {
   fetch: FetchCallback

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -8,7 +8,7 @@ import { compress } from 'hono/compress'
 import { poweredBy } from 'hono/powered-by'
 import request from 'supertest'
 import { createAdaptorServer } from '../src/server'
-import type { RawBindings } from '../src/types'
+import type { HttpBindings } from '../src/types'
 
 describe('Basic', () => {
   const app = new Hono()
@@ -544,7 +544,7 @@ describe('set child response to c.res', () => {
 })
 
 describe('forwarding IncomingMessage and ServerResponse in env', () => {
-  const app = new Hono<{ Bindings: RawBindings }>()
+  const app = new Hono<{ Bindings: HttpBindings }>()
   app.get('/', (c) => c.json({
     incoming: c.env.incoming.constructor.name,
     url: c.env.incoming.url,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs'
-import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createServer as createHttp2Server } from 'node:http2'
 import { createServer as createHTTPSServer } from 'node:https'
 import { Response as PonyfillResponse } from '@whatwg-node/fetch'
@@ -9,6 +8,7 @@ import { compress } from 'hono/compress'
 import { poweredBy } from 'hono/powered-by'
 import request from 'supertest'
 import { createAdaptorServer } from '../src/server'
+import type { RawBindings } from '../src/types'
 
 describe('Basic', () => {
   const app = new Hono()
@@ -542,11 +542,6 @@ describe('set child response to c.res', () => {
     expect(res.headers['content-type']).toMatch(/application\/json/)
   })
 })
-
-type RawBindings = {
-  incoming: IncomingMessage
-  outgoing: ServerResponse
-}
 
 describe('forwarding IncomingMessage and ServerResponse in env', () => {
   const app = new Hono<{ Bindings: RawBindings }>()


### PR DESCRIPTION
Makes the raw `IncomingMessage` and `ServerResponse` instances accessible via `c.env` the [same way](https://github.com/honojs/hono/blob/main/src/adapter/aws-lambda/handler.ts#L158-L162) that [`hono/aws-lambda` does it](https://hono.dev/getting-started/aws-lambda#access-requestcontext).

After implementing it I saw that #90 does the same thing, but I thought I may as well submit it as it is smaller in scope.

```ts
type Bindings = {
  incoming: IncomingMessage
  outgoing: ServerResponse
}

const app = new Hono<{ Bindings: Bindings}>()

app.get('/', (c) => {
  console.log(c.env.incoming.url)
})
```

Related: #80 #90 #122