### PR TITLE
feat(listener): support custom error handler

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -62,7 +62,9 @@ const responseViaResponseObject = async (
         res = await res
       } catch (err) {
         const errRes = await options.errorHandler(err)
-        if (!errRes) return
+        if (!errRes) {
+          return
+        }
         res = errRes
       }
     } else {
@@ -153,7 +155,9 @@ export const getRequestListener = (
       if (!res) {
         if (options.errorHandler) {
           res = await options.errorHandler(e)
-          if (!res) return
+          if (!res) {
+            return
+          }
         } else {
           res = handleFetchError(e)
         }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -52,14 +52,14 @@ const responseViaCache = (
 const responseViaResponseObject = async (
   res: Response | Promise<Response>,
   outgoing: ServerResponse | Http2ServerResponse,
-  customErrorHandler?: (e: unknown) => void
+  options: { errorHandler?: (e: unknown) => void } = {}
 ) => {
   if (res instanceof Promise) {
-    if (customErrorHandler) {
+    if (options.errorHandler) {
       try {
         res = await res
       } catch (err) {
-        return customErrorHandler(err)
+        return options.errorHandler(err)
       }
     } else {
       res = await res.catch(handleFetchError)
@@ -114,7 +114,7 @@ const responseViaResponseObject = async (
 
 export const getRequestListener = (
   fetchCallback: FetchCallback,
-  customErrorHandler?: (e: unknown) => void
+  options: { errorHandler?: (e: unknown) => void } = {}
 ) => {
   return (
     incoming: IncomingMessage | Http2ServerRequest,
@@ -134,8 +134,8 @@ export const getRequestListener = (
       }
     } catch (e: unknown) {
       if (!res) {
-        if (customErrorHandler) {
-          return customErrorHandler(e)
+        if (options.errorHandler) {
+          return options.errorHandler(e)
         }
 
         res = handleFetchError(e)
@@ -144,6 +144,6 @@ export const getRequestListener = (
       }
     }
 
-    return responseViaResponseObject(res, outgoing, customErrorHandler)
+    return responseViaResponseObject(res, outgoing, options)
   }
 }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -157,7 +157,6 @@ export const getRequestListener = (
         } else {
           res = handleFetchError(e)
         }
-
       } else {
         return handleResponseError(e, outgoing)
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,3 +72,5 @@ export type Options = {
   port?: number
   hostname?: string
 } & ServerOptions
+
+export type CustomErrorHandler = (err: unknown) => void | Response | Promise<void | Response>

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -1,0 +1,91 @@
+import { createServer } from 'node:http'
+import request from 'supertest'
+import { getRequestListener } from '../src/listener'
+
+describe('Error handling - sync fetchCallback', () => {
+  const fetchCallback = jest.fn(() => {
+    throw new Error('thrown error')
+  })
+  const errorHandler = jest.fn()
+
+  const requestListener = getRequestListener(fetchCallback, { errorHandler })
+
+  const server = createServer(async (req, res) => {
+    await requestListener(req, res)
+
+    if (!res.writableEnded) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' })
+      res.end('error handler did not return a response')
+    }
+  })
+
+  beforeEach(() => {
+    errorHandler.mockReset()
+  })
+
+  it('Should set the response if error handler returns a response', async () => {
+    errorHandler.mockImplementationOnce((err: Error) => {
+      return new Response(`${err}`, { status: 500, headers: { 'my-custom-header': 'hi' } })
+    })
+
+    const res = await request(server).get('/throw-error')
+    expect(res.status).toBe(500)
+    expect(res.headers['my-custom-header']).toBe('hi')
+    expect(res.text).toBe('Error: thrown error')
+  })
+
+  it('Should not set the response if the error handler does not return a response', async () => {
+    errorHandler.mockImplementationOnce(() => {
+      // do something else, such as passing error to vite next middleware, etc
+    })
+
+    const res = await request(server).get('/throw-error')
+    expect(errorHandler).toHaveBeenCalledTimes(1)
+    expect(res.status).toBe(500)
+    expect(res.text).toBe('error handler did not return a response')
+  })
+})
+
+describe('Error handling - async fetchCallback', () => {
+  const fetchCallback = jest.fn(async () => {
+    throw new Error('thrown error')
+  })
+  const errorHandler = jest.fn()
+
+  const requestListener = getRequestListener(fetchCallback, { errorHandler })
+
+  const server = createServer(async (req, res) => {
+    await requestListener(req, res)
+
+    if (!res.writableEnded) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' })
+      res.end('error handler did not return a response')
+    }
+  })
+
+  beforeEach(() => {
+    errorHandler.mockReset()
+  })
+
+  it('Should set the response if error handler returns a response', async () => {
+    errorHandler.mockImplementationOnce((err: Error) => {
+      return new Response(`${err}`, { status: 500, headers: { 'my-custom-header': 'hi' } })
+    })
+
+    const res = await request(server).get('/throw-error')
+    expect(res.status).toBe(500)
+    expect(res.headers['my-custom-header']).toBe('hi')
+    expect(res.text).toBe('Error: thrown error')
+  })
+
+  it('Should not set the response if the error handler does not return a response', async () => {
+    errorHandler.mockImplementationOnce(() => {
+      // do something else, such as passing error to vite next middleware, etc
+    })
+
+    const res = await request(server).get('/throw-error')
+    expect(errorHandler).toHaveBeenCalledTimes(1)
+    expect(res.status).toBe(500)
+    expect(res.text).toBe('error handler did not return a response')
+  })
+})


### PR DESCRIPTION
Would ya'll be open to this kind of option? 

Open to alternative approaches, but basically what I'm after is a means for the consumer to be able to provide it's own error handler so that it can, for example, pass the error down the middleware chain in a Vite dev server. This allows vite to display the standard pretty error overlay on the client, etc.

See example of how it can be used in https://github.com/honojs/vite-plugins/pull/63 (this PR blocks that PR).