### PR TITLE
feat(request): Enable to create Request from light weight request.

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,9 +1,4 @@
 import crypto from 'node:crypto'
-import { Response } from './response'
-
-Object.defineProperty(global, 'Response', {
-  value: Response,
-})
 
 const webFetch = global.fetch
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,42 +1,87 @@
 import type { IncomingMessage } from 'node:http'
-import { newRequest } from '../src/request'
+import { newRequest, Request, GlobalRequest } from '../src/request'
 
 describe('Request', () => {
-  it('Compatibility with standard Request object', async () => {
-    const req = newRequest({
-      method: 'GET',
-      url: '/',
-      headers: {
-        host: 'localhost',
-      },
-      rawHeaders: ['host', 'localhost'],
-    } as IncomingMessage)
+  describe('newRequest', () => {
+    it('Compatibility with standard Request object', async () => {
+      const req = newRequest({
+        method: 'GET',
+        url: '/',
+        headers: {
+          host: 'localhost',
+        },
+        rawHeaders: ['host', 'localhost'],
+      } as IncomingMessage)
 
-    expect(req).toBeInstanceOf(global.Request)
-    expect(req.method).toBe('GET')
-    expect(req.url).toBe('http://localhost/')
-    expect(req.headers.get('host')).toBe('localhost')
+      expect(req).toBeInstanceOf(global.Request)
+      expect(req.method).toBe('GET')
+      expect(req.url).toBe('http://localhost/')
+      expect(req.headers.get('host')).toBe('localhost')
+    })
+
+    it('Should resolve double dots in URL', async () => {
+      const req = newRequest({
+        headers: {
+          host: 'localhost',
+        },
+        url: '/static/../foo.txt',
+      } as IncomingMessage)
+      expect(req).toBeInstanceOf(global.Request)
+      expect(req.url).toBe('http://localhost/foo.txt')
+    })
+
+    it('Should resolve double dots in host header', async () => {
+      const req = newRequest({
+        headers: {
+          host: 'localhost/..',
+        },
+        url: '/foo.txt',
+      } as IncomingMessage)
+      expect(req).toBeInstanceOf(global.Request)
+      expect(req.url).toBe('http://localhost/foo.txt')
+    })
   })
 
-  it('Should resolve double dots in URL', async () => {
-    const req = newRequest({
-      headers: {
-        host: 'localhost',
-      },
-      url: '/static/../foo.txt',
-    } as IncomingMessage)
-    expect(req).toBeInstanceOf(global.Request)
-    expect(req.url).toBe('http://localhost/foo.txt')
-  })
+  describe('GlobalRequest', () => {
+    it('should be overrode by Request', () => {
+      expect(Request).not.toBe(GlobalRequest)
+    })
 
-  it('Should resolve double dots in host header', async () => {
-    const req = newRequest({
-      headers: {
-        host: 'localhost/..',
-      },
-      url: '/foo.txt',
-    } as IncomingMessage)
-    expect(req).toBeInstanceOf(global.Request)
-    expect(req.url).toBe('http://localhost/foo.txt')
+    it('should be instance of GlobalRequest', () => {
+      const req = new Request('http://localhost/')
+      expect(req).toBeInstanceOf(GlobalRequest)
+    })
+
+    it('should be success to create instance from old light weight instance', async () => {
+      const req = newRequest({
+        method: 'GET',
+        url: '/',
+        headers: {
+          host: 'localhost',
+        },
+        rawHeaders: ['host', 'localhost'],
+      } as IncomingMessage)
+      const req2 = new Request(req, {
+        method: 'POST',
+        body: 'foo',
+      })
+      expect(req2).toBeInstanceOf(GlobalRequest)
+      expect(await req2.text()).toBe('foo')
+    })
+
+    it('should set `duplex: "half"` automatically if body is a ReadableStream', async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('bar'))
+          controller.close()
+        },
+      })
+      const req2 = new Request('http://localhost', {
+        method: 'POST',
+        body: stream,
+      })
+      expect(req2).toBeInstanceOf(GlobalRequest)
+      expect(req2.text()).resolves.toBe('bar')
+    })
   })
 })

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -40,6 +40,10 @@ describe('Response', () => {
     server.close()
   })
 
+  it('Should be overrode by Response', () => {
+    expect(Response).not.toBe(GlobalResponse)
+  })
+
   it('Compatibility with standard Response object', async () => {
     // response name not changed
     expect(Response.name).toEqual('Response')

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,3 +2,7 @@ Object.defineProperty(global, 'Response', {
   value: global.Response,
   writable: true,
 })
+Object.defineProperty(global, 'Request', {
+  value: global.Request,
+  writable: true,
+})


### PR DESCRIPTION
This PR allows the following code to work, making it easy to replace the Request object in hono.

https://github.com/honojs/node-server/compare/main...usualoma:node-server:feat/create-request-from-request?expand=1#diff-e7c9480196e722de595dba06f56ad6601bce3d0e66651e7b77eea71f93be2ac3R55-R85