### PR TITLE
Catch when nodejs request is aborted

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'node:http'
 import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
-import { newRequest } from './request'
+import { getAbortController, newRequest } from './request'
 import { cacheKey } from './response'
 import type { CustomErrorHandler, FetchCallback, HttpBindings } from './types'
 import { writeFromReadableStream, buildOutgoingHttpHeaders } from './utils'
@@ -142,6 +142,13 @@ export const getRequestListener = (
     // `fetchCallback()` requests a Request object, but global.Request is expensive to generate,
     // so generate a pseudo Request object with only the minimum required information.
     const req = newRequest(incoming)
+
+    // Detect if request was aborted.
+    outgoing.on('close', () => {
+      if (incoming.destroyed) {
+        req[getAbortController]().abort()
+      }
+    })
 
     try {
       res = fetchCallback(req, { incoming, outgoing } as HttpBindings) as

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from 'node:http'
-import { newRequest, Request, GlobalRequest } from '../src/request'
+import { newRequest, Request, GlobalRequest, getAbortController } from '../src/request'
 
 describe('Request', () => {
   describe('newRequest', () => {
@@ -39,6 +39,34 @@ describe('Request', () => {
       } as IncomingMessage)
       expect(req).toBeInstanceOf(global.Request)
       expect(req.url).toBe('http://localhost/foo.txt')
+    })
+
+    it('should generate only one `AbortController` per `Request` object created', async () => {
+      const req = newRequest({
+        headers: {
+          host: 'localhost/..',
+        },
+        rawHeaders: ['host', 'localhost/..'],
+        url: '/foo.txt',
+      } as IncomingMessage)
+      const req2 = newRequest({
+        headers: {
+          host: 'localhost/..',
+        },
+        rawHeaders: ['host', 'localhost/..'],
+        url: '/foo.txt',
+      } as IncomingMessage)
+
+      const x = req[getAbortController]()
+      const y = req[getAbortController]()
+      const z = req2[getAbortController]()
+
+      expect(x).toBeInstanceOf(AbortController)
+      expect(y).toBeInstanceOf(AbortController)
+      expect(z).toBeInstanceOf(AbortController)
+      expect(x).toBe(y)
+      expect(z).not.toBe(x)
+      expect(z).not.toBe(y)
     })
   })
 


### PR DESCRIPTION
When we receive a request, we start listening to the close event. When fired, we check if the request was aborted using `incoming.aborted`, if it was, we dispatch an abort event to the existing request abort signal.

Without this, when the client aborts the request, the signal on the request was not being called with the abort event.

Closes: https://github.com/honojs/node-server/issues/107