### PR TITLE
feat: raise an abort event when the nodejs request is aborted

### DIFF
--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -89,3 +89,54 @@ describe('Error handling - async fetchCallback', () => {
     expect(res.text).toBe('error handler did not return a response')
   })
 })
+
+describe('Abort request', () => {
+  let onAbort: (req: Request) => void
+  let reqReadyResolve: () => void
+  let reqReadyPromise: Promise<void>
+  const fetchCallback = async (req: Request) => {
+    req.signal.addEventListener('abort', () => onAbort(req))
+    reqReadyResolve?.()
+    await new Promise(() => {}) // never resolve
+  }
+
+  const requestListener = getRequestListener(fetchCallback)
+
+  const server = createServer(async (req, res) => {
+    await requestListener(req, res)
+  })
+
+  beforeEach(() => {
+    reqReadyPromise = new Promise<void>((r) => {
+      reqReadyResolve = r
+    })
+  })
+
+  it('should emit an abort event when the nodejs request is aborted', async () => {
+    const requests: Request[] = []
+    const abortedPromise = new Promise<void>((resolve) => {
+      onAbort = (req) => {
+        requests.push(req)
+        resolve()
+      }
+    })
+
+    const req = request(server)
+      .get('/abort')
+      .end(() => {})
+
+    await reqReadyPromise
+
+    req.abort()
+
+    await abortedPromise
+
+    const abortedReq = requests[0]
+    expect(abortedReq).toBeInstanceOf(Request)
+    expect(abortedReq.signal.aborted).toBe(true)
+
+    // force close the server to avoid jest open handle error
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(req as any)._server.close()
+  })
+})


### PR DESCRIPTION
This is not a proposed change, but an example implementation.