### PR TITLE
feat: validate incoming host header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { serve, createAdaptorServer } from './server'
 export { getRequestListener } from './listener'
+export { RequestError } from './request'
 export type { HttpBindings, Http2Bindings } from './types'

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -1,6 +1,11 @@
 import type { IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'node:http'
 import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
-import { getAbortController, newRequest, Request as LightweightRequest } from './request'
+import {
+  getAbortController,
+  newRequest,
+  Request as LightweightRequest,
+  toRequestError,
+} from './request'
 import { cacheKey, getInternalBody, Response as LightweightResponse } from './response'
 import type { CustomErrorHandler, FetchCallback, HttpBindings } from './types'
 import { writeFromReadableStream, buildOutgoingHttpHeaders } from './utils'
@@ -9,6 +14,11 @@ import './globals'
 
 const regBuffer = /^no$/i
 const regContentType = /^(application\/json\b|text\/(?!event-stream\b))/i
+
+const handleRequestError = (): Response =>
+  new Response(null, {
+    status: 400,
+  })
 
 const handleFetchError = (e: unknown): Response =>
   new Response(null, {
@@ -157,12 +167,13 @@ export const getRequestListener = (
     incoming: IncomingMessage | Http2ServerRequest,
     outgoing: ServerResponse | Http2ServerResponse
   ) => {
-    let res
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let res, req: any
 
     try {
       // `fetchCallback()` requests a Request object, but global.Request is expensive to generate,
       // so generate a pseudo Request object with only the minimum required information.
-      const req = newRequest(incoming)
+      req = newRequest(incoming)
 
       // Detect if request was aborted.
       outgoing.on('close', () => {
@@ -181,10 +192,12 @@ export const getRequestListener = (
     } catch (e: unknown) {
       if (!res) {
         if (options.errorHandler) {
-          res = await options.errorHandler(e)
+          res = await options.errorHandler(req ? e : toRequestError(e))
           if (!res) {
             return
           }
+        } else if (!req) {
+          res = handleRequestError()
         } else {
           res = handleFetchError(e)
         }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -150,6 +150,7 @@ const responseViaResponseObject = async (
 export const getRequestListener = (
   fetchCallback: FetchCallback,
   options: {
+    hostname?: string
     errorHandler?: CustomErrorHandler
     overrideGlobalObjects?: boolean
   } = {}
@@ -173,7 +174,7 @@ export const getRequestListener = (
     try {
       // `fetchCallback()` requests a Request object, but global.Request is expensive to generate,
       // so generate a pseudo Request object with only the minimum required information.
-      req = newRequest(incoming)
+      req = newRequest(incoming, options.hostname)
 
       // Detect if request was aborted.
       outgoing.on('close', () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -130,11 +130,16 @@ const requestPrototype: Record<string | symbol, any> = {
 })
 Object.setPrototypeOf(requestPrototype, Request.prototype)
 
-export const newRequest = (incoming: IncomingMessage | Http2ServerRequest) => {
+export const newRequest = (
+  incoming: IncomingMessage | Http2ServerRequest,
+  defaultHostname?: string
+) => {
   const req = Object.create(requestPrototype)
   req[incomingKey] = incoming
 
-  const host = incoming instanceof Http2ServerRequest ? incoming.authority : incoming.headers.host
+  const host =
+    (incoming instanceof Http2ServerRequest ? incoming.authority : incoming.headers.host) ||
+    defaultHostname
   if (!host) {
     throw new RequestError('Missing host header')
   }

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,25 @@ import { Http2ServerRequest } from 'node:http2'
 import { Readable } from 'node:stream'
 import type { TLSSocket } from 'node:tls'
 
+export class RequestError extends Error {
+  static name = 'RequestError'
+  constructor(
+    message: string,
+    options?: {
+      cause?: unknown
+    }
+  ) {
+    super(message, options)
+  }
+}
+
+export const toRequestError = (e: unknown): RequestError => {
+  if (e instanceof RequestError) {
+    return e
+  }
+  return new RequestError((e as Error).message, { cause: e })
+}
+
 export const GlobalRequest = global.Request
 export class Request extends GlobalRequest {
   constructor(input: string | Request, options?: RequestInit) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import type { Options, ServerType } from './types'
 export const createAdaptorServer = (options: Options): ServerType => {
   const fetchCallback = options.fetch
   const requestListener = getRequestListener(fetchCallback, {
+    hostname: options.hostname,
     overrideGlobalObjects: options.overrideGlobalObjects,
   })
   // ts will complain about createServerHTTP and createServerHTTP2 not being callable, which works just fine

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -17,12 +17,12 @@ describe('Invalid request', () => {
 
   it('Should return server error for a request w/o host header', async () => {
     const res = await request(server).get('/').set('Host', '').send()
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
   })
 
   it('Should return server error for a request invalid host header', async () => {
     const res = await request(server).get('/').set('Host', 'a b').send()
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
   })
 })
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -41,29 +41,29 @@ describe('Request', () => {
     })
 
     it('Should resolve double dots in host header', async () => {
-      const req = newRequest({
-        headers: {
-          host: 'localhost/..',
-        },
-        url: '/foo.txt',
-      } as IncomingMessage)
-      expect(req).toBeInstanceOf(global.Request)
-      expect(req.url).toBe('http://localhost/foo.txt')
+      expect(() => {
+        newRequest({
+          headers: {
+            host: 'localhost/..',
+          },
+          url: '/foo.txt',
+        } as IncomingMessage)
+      }).toThrow('Invalid host header')
     })
 
     it('should generate only one `AbortController` per `Request` object created', async () => {
       const req = newRequest({
         headers: {
-          host: 'localhost/..',
+          host: 'localhost',
         },
-        rawHeaders: ['host', 'localhost/..'],
+        rawHeaders: ['host', 'localhost'],
         url: '/foo.txt',
       } as IncomingMessage)
       const req2 = newRequest({
         headers: {
-          host: 'localhost/..',
+          host: 'localhost',
         },
-        rawHeaders: ['host', 'localhost/..'],
+        rawHeaders: ['host', 'localhost'],
         url: '/foo.txt',
       } as IncomingMessage)
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -4,6 +4,7 @@ import {
   Request as LightweightRequest,
   GlobalRequest,
   getAbortController,
+  RequestError,
 } from '../src/request'
 
 Object.defineProperty(global, 'Request', {
@@ -40,15 +41,15 @@ describe('Request', () => {
       expect(req.url).toBe('http://localhost/foo.txt')
     })
 
-    it('Should resolve double dots in host header', async () => {
-      expect(() => {
-        newRequest({
-          headers: {
-            host: 'localhost/..',
-          },
-          url: '/foo.txt',
-        } as IncomingMessage)
-      }).toThrow('Invalid host header')
+    it('Should accept hostname and port in host header', async () => {
+      const req = newRequest({
+        headers: {
+          host: 'localhost:8080',
+        },
+        url: '/static/../foo.txt',
+      } as IncomingMessage)
+      expect(req).toBeInstanceOf(global.Request)
+      expect(req.url).toBe('http://localhost:8080/foo.txt')
     })
 
     it('should generate only one `AbortController` per `Request` object created', async () => {
@@ -77,6 +78,39 @@ describe('Request', () => {
       expect(x).toBe(y)
       expect(z).not.toBe(x)
       expect(z).not.toBe(y)
+    })
+
+    it('Should throw error if host header contains path', async () => {
+      expect(() => {
+        newRequest({
+          headers: {
+            host: 'localhost/..',
+          },
+          url: '/foo.txt',
+        } as IncomingMessage)
+      }).toThrow(RequestError)
+    })
+
+    it('Should throw error if host header is empty', async () => {
+      expect(() => {
+        newRequest({
+          headers: {
+            host: '',
+          },
+          url: '/foo.txt',
+        } as IncomingMessage)
+      }).toThrow(RequestError)
+    })
+
+    it('Should throw error if host header contains query parameter', async () => {
+      expect(() => {
+        newRequest({
+          headers: {
+            host: 'localhost?foo=bar',
+          },
+          url: '/foo.txt',
+        } as IncomingMessage)
+      }).toThrow(RequestError)
     })
   })
 


### PR DESCRIPTION
fixes #160, #161

### What is this?

Validate the content of the host header of the request for security purposes.

### Invalid values

If the following values are specified in the host header, a "400 Bad Request" is returned.

* Empty string (if no default hostname is specified)
* Including path or query parameter
    * `localhost/path` `localhost?key=value`
* Including invalid charactors
    * `localhost<script>`

### Valid values

Host headers are only validated by character type, so "hostnames with invalid structure" or "hostnames that cannot be looked up" are considered valid and do not result in a "400 Bad Request". For example, the following host headers are considered valid
* `.` `www...example.com`  `()`

### Default hostname

If you also want to accept HTTP 1.0 requests w/o Host header, you can call `serve()` as follows to ensure that the default hostname is used without error if there is no host header (or an empty string is specified).

```ts
serve({
    fetch: app.fetch,
    hostname: 'localhost', // should be associated with the IP address of the server
})
```


### Tasks

* [x] implement
* [x] test