### PR TITLE
Update Request to work with ReadableStream polyfills

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -31,7 +31,8 @@ export class Request extends GlobalRequest {
     if (typeof input === 'object' && getRequestCache in input) {
       input = (input as any)[getRequestCache]()
     }
-    if (options?.body instanceof ReadableStream) {
+    // Check if body is ReadableStream like. This makes it compatbile with ReadableStream polyfills. 
+    if (typeof options?.body?.getReader !== "undefined") {
       // node 18 fetch needs half duplex mode when request body is stream
       // if already set, do nothing since a Request object was passed to the options or explicitly set by the user.
       ;(options as any).duplex ??= 'half'

--- a/src/request.ts
+++ b/src/request.ts
@@ -31,8 +31,8 @@ export class Request extends GlobalRequest {
     if (typeof input === 'object' && getRequestCache in input) {
       input = (input as any)[getRequestCache]()
     }
-    // Check if body is ReadableStream like. This makes it compatbile with ReadableStream polyfills. 
-    if (typeof options?.body?.getReader !== "undefined") {
+    // Check if body is ReadableStream like. This makes it compatbile with ReadableStream polyfills.
+    if (typeof options?.body?.getReader !== 'undefined') {
       // node 18 fetch needs half duplex mode when request body is stream
       // if already set, do nothing since a Request object was passed to the options or explicitly set by the user.
       ;(options as any).duplex ??= 'half'

--- a/src/request.ts
+++ b/src/request.ts
@@ -32,7 +32,7 @@ export class Request extends GlobalRequest {
       input = (input as any)[getRequestCache]()
     }
     // Check if body is ReadableStream like. This makes it compatbile with ReadableStream polyfills.
-    if (typeof options?.body?.getReader !== 'undefined') {
+    if (typeof (options?.body as ReadableStream)?.getReader !== 'undefined') {
       // node 18 fetch needs half duplex mode when request body is stream
       // if already set, do nothing since a Request object was passed to the options or explicitly set by the user.
       ;(options as any).duplex ??= 'half'

--- a/src/response.ts
+++ b/src/response.ts
@@ -40,7 +40,7 @@ export class Response {
       this.#init = init
     }
 
-    if (typeof body === 'string' || body instanceof ReadableStream) {
+    if (typeof body === 'string' || typeof body?.getReader !== "undefined") {
       let headers = (init?.headers || { 'content-type': 'text/plain; charset=UTF-8' }) as
         | Record<string, string>
         | Headers

--- a/src/response.ts
+++ b/src/response.ts
@@ -40,7 +40,7 @@ export class Response {
       this.#init = init
     }
 
-    if (typeof body === 'string' || typeof body?.getReader !== 'undefined') {
+    if (typeof body === 'string' || typeof (body as ReadableStream)?.getReader !== 'undefined') {
       let headers = (init?.headers || { 'content-type': 'text/plain; charset=UTF-8' }) as
         | Record<string, string>
         | Headers

--- a/src/response.ts
+++ b/src/response.ts
@@ -40,7 +40,7 @@ export class Response {
       this.#init = init
     }
 
-    if (typeof body === 'string' || typeof body?.getReader !== "undefined") {
+    if (typeof body === 'string' || typeof body?.getReader !== 'undefined') {
       let headers = (init?.headers || { 'content-type': 'text/plain; charset=UTF-8' }) as
         | Record<string, string>
         | Headers


### PR DESCRIPTION
Some web frameworks (like Remix) inject polyfills for ReadableStream into the Node Runtime.  This change makes sure that the server will work correctly with those polyfills. Otherwise the `instanceof` check would fail. 