### PR TITLE
ci: include tests for node 22 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,22 @@ on:
   pull_request:
     branches: ['*']
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x, 20.x]
+        node-version: [18.x, 19.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
Node.js 22 will enter long-term support (LTS) in October, so I think it would be a good idea to start running CI on it now.

I've also added workflow permissions and increased action versions.