### PR TITLE
fix:  memory leak by AbortController

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "scripts": {
-    "test": "jest",
+    "test": "node --expose-gc ./node_modules/.bin/jest",
     "build": "tsup",
     "watch": "tsup --watch",
     "postbuild": "publint",

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -179,7 +179,7 @@ export const getRequestListener = (
       // Detect if request was aborted.
       outgoing.on('close', () => {
         if (incoming.errored) {
-          req[getAbortController]().abort()
+          req[getAbortController]().abort(incoming.errored.toString())
         }
       })
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -178,7 +178,7 @@ export const getRequestListener = (
 
       // Detect if request was aborted.
       outgoing.on('close', () => {
-        if (incoming.destroyed) {
+        if (incoming.errored) {
           req[getAbortController]().abort()
         }
       })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,11 @@
       "jest",
       "node",
     ],
-    "rootDir": "./src",
+    "rootDir": ".",
     "outDir": "./dist",
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "test/**/*.ts"
   ],
 }


### PR DESCRIPTION
Fixes #171, https://github.com/honojs/hono/issues/2816

Two issues needed to be corrected in this issue.

### `incoming.destroyed` is true for all POST requests

[The documentation](https://nodejs.org/api/http.html#requestaborted) says "Deprecated. check request.destroyed instead."

![CleanShot 2024-05-30 at 05 17 02@2x](https://github.com/honojs/node-server/assets/30598/d1ad0a32-5e67-4c0a-81ff-3fefee569738)

However, incoming was flagged for “autodestroy" and `incoming.destroy()` was always called when the request body was read to the end. In other words, `.abort()` was always called in POST requests. POST requests complete successfully, so there are no major problems, but I think it was not a good behaviour.

https://github.com/nodejs/node/blob/c0c598d753d5ce7e1721215c6e6254dc02c023a8/lib/internal/streams/readable.js#L1690-L1716

As [errored](https://nodejs.org/api/stream.html#readableerrored) seemed more suitable for our application, I decided to use it.

### `.abort()` (call without arguments) causes memory leak

The real problem of memory leaks is here, which was an interesting situation.

Calling `abort()` with no arguments uses an instance of `DOMException`, but (presumably) this object is referenced including its children and grandchildren, so it appears that a cycle of references occurs and a instance of AbortController cannot be freed.

https://github.com/nodejs/node/blob/c0c598d753d5ce7e1721215c6e6254dc02c023a8/lib/internal/abort_controller.js#L395-L397
https://github.com/nodejs/node/blob/c0c598d753d5ce7e1721215c6e6254dc02c023a8/lib/internal/abort_controller.js#L368-L378

For "reason", not only for `DOMException`, it seems to be necessary to pass a string, as specifying an `Object` seems to cause a memory leak.

### tsconfig.json

In order to use `FinalisationRegistry` in server.test.ts, the settings in tsconfig.json needed to be reflected in server.test.ts, so tsconfig.json was changed.

32c09a9b1b56220c8c3bdd1b0c01189933d41ecc