### PR TITLE
Update readme with an example of proper "root" when using serveStatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,26 @@ import { serveStatic } from '@hono/node-server/serve-static'
 app.use('/static/*', serveStatic({ root: './' }))
 ```
 
-Note that `root` must be _relative_ to the current working directory - absolute paths are not supported.
+Note that `root` must be _relative_ to the current working directory. Absolute paths are not supported.
+
+This can cause confusion when running your application locally.
+
+Imagine your project structure is:
+
+```
+my-hono-project/
+  src/
+    index.ts
+  static/
+    index.html
+```
+
+Typically, you would run your app from the project's root directory (`my-hono-project`), 
+so you would need the following code to serve the `static` folder:
+
+```ts
+app.use('/static/*', serveStatic({ root: './static' }))
+```
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ import { serveStatic } from '@hono/node-server/serve-static'
 app.use('/static/*', serveStatic({ root: './' }))
 ```
 
-Note that `root` must be _relative_ to the current working directory. Absolute paths are not supported.
+Note that `root` must be _relative_ to the current working directory from which the app was started. Absolute paths are not supported.
 
 This can cause confusion when running your application locally.
 
@@ -175,6 +175,8 @@ so you would need the following code to serve the `static` folder:
 ```ts
 app.use('/static/*', serveStatic({ root: './static' }))
 ```
+
+Notice that `root` here is not relative to `src/index.ts`, rather to `my-hono-project`.
 
 ### Options
 

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -6,7 +6,7 @@ import { getMimeType } from 'hono/utils/mime'
 
 export type ServeStaticOptions = {
   /**
-   * Root path, relative to current working directory. (absolute paths are not supported)
+   * Root path, relative to current working directory from which the app was started. Absolute paths are not supported.
    */
   root?: string
   path?: string


### PR DESCRIPTION
Also update the ts doc string for this parameter to be clearer

***

I noticed [in Discord](https://discord.com/channels/1011308539819597844/1012485912409690122/1247001132648239114) that people have trouble with the `root` parameter when using `serveStatic`. I also ran into this issue myself!

This PR updates the README with an example that should hopefully make its usage clearer.