### PR TITLE
fix: avoid error when using TRACE method

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -62,6 +62,17 @@ const newRequestFromIncoming = (
     signal: abortController.signal,
   } as RequestInit
 
+  if (method === 'TRACE') {
+    init.method = 'GET'
+    const req = new Request(url, init)
+    Object.defineProperty(req, 'method', {
+      get() {
+        return 'TRACE'
+      },
+    })
+    return req
+  }
+
   if (!(method === 'GET' || method === 'HEAD')) {
     // lazy-consume request body
     init.body = Readable.toWeb(incoming) as ReadableStream<Uint8Array>

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -38,6 +38,11 @@ describe('Basic', () => {
     return new PonyfillResponse('Pony')
   })
 
+  app.on('trace', '/', (c) => {
+    const headers = c.req.raw.headers // build new request object
+    return c.text(`headers: ${JSON.stringify(headers)}`)
+  })
+
   const server = createAdaptorServer(app)
 
   it('Should return 200 response - GET /', async () => {
@@ -93,6 +98,11 @@ describe('Basic', () => {
     expect(res.status).toBe(200)
     expect(res.headers['content-type']).toMatch('text/plain')
     expect(res.text).toBe('Pony')
+  })
+
+  it('Should not raise error for TRACE method', async () => {
+    const res = await request(server).trace('/')
+    expect(res.text).toBe('headers: {}')
   })
 })
 


### PR DESCRIPTION
fixes #167

The Request object defined in undici is an error if we try to create it by specifying the TRACE method. In this pull request, create it by specifying the GET method to avoid this.