### PR TITLE
feat: add custom headers option to serve static

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,23 @@ app.use(
 )
 ```
 
+#### `headers`
+
+If you need to set headers for the served files, you can use the `headers` option.
+
+```ts
+app.use(
+  '/static/*',
+  serveStatic({
+    root: './static',
+    headers: (c) => ({
+      'Cache-Control': 'public, max-age=31536000',
+      'X-Filepath': c.req.path,
+    }),
+  })
+)
+```
+
 ## ConnInfo Helper
 
 You can use the [ConnInfo Helper](https://hono.dev/docs/helpers/conninfo) by importing `getConnInfo` from `@hono/node-server/conninfo`.

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -11,6 +11,7 @@ export type ServeStaticOptions = {
   root?: string
   path?: string
   index?: string // default is 'index.html'
+  headers?: (c: Context) => Record<string, string | undefined>
   rewriteRequestPath?: (path: string) => string
   onNotFound?: (path: string, c: Context) => void | Promise<void>
 }
@@ -86,6 +87,15 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
     if (!stats) {
       await options.onNotFound?.(path, c)
       return next()
+    }
+
+    const headers = options.headers?.(c)
+    if (headers) {
+      for (const [key, value] of Object.entries(headers)) {
+        if (value) {
+          c.header(key, value)
+        }
+      }
     }
 
     const mimeType = getMimeType(path)

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -15,6 +15,13 @@ describe('Serve Static Middleware', () => {
       rewriteRequestPath: (path) => path.replace(/^\/dot-static/, '/.static'),
     })
   )
+  app.use(
+    '/immutable-icon.ico',
+    serveStatic({
+      path: './test/assets/favicon.ico',
+      headers: () => ({ 'Cache-Control': 'public, max-age=31536000, immutable' }),
+    })
+  )
 
   let notFoundMessage = ''
   app.use(
@@ -65,6 +72,12 @@ describe('Serve Static Middleware', () => {
     expect(res.status).toBe(200)
     expect(res.headers['content-type']).toBe('text/plain; charset=utf-8')
     expect(res.text).toBe('This is plain.txt')
+  })
+
+  it('Should return custom headers', async () => {
+    const res = await request(server).get('/immutable-icon.ico')
+    expect(res.status).toBe(200)
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable')
   })
 
   it('Should return 404 for non-existent files', async () => {


### PR DESCRIPTION
I was creating a custom server which would serve built css/js files, the files are hashed which means I can make their cache-control headers immutable.
`serveStatic` does not have an option to set any custom headers, so I added a new option that takes a function which can set custom headers and has the context as a parameter.

I have updated the tests and Readme to reflect the changes.
