### PR TITLE
fix(serve-static): use application/octet-stream if the mime type is not detected

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -101,9 +101,7 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
     await options.onFound?.(path, c)
 
     const mimeType = getMimeType(path)
-    if (mimeType) {
-      c.header('Content-Type', mimeType)
-    }
+    c.header('Content-Type', mimeType || 'application/octet-stream')
 
     if (options.precompressed && (!mimeType || COMPRESSIBLE_CONTENT_TYPE_REGEX.test(mimeType))) {
       const acceptEncodingSet = new Set(

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -155,7 +155,8 @@ describe('Serve Static Middleware', () => {
   it('Should handle an extension less files', async () => {
     const res = await request(server).get('/static/extensionless')
     expect(res.status).toBe(200)
-    expect(res.text).toBe('Extensionless')
+    expect(res.headers['content-type']).toBe('application/octet-stream')
+    expect(res.body.toString()).toBe('Extensionless')
   })
 
   it('Should return a pre-compressed zstd response - /static-with-precompressed/hello.txt', async () => {


### PR DESCRIPTION
This pull request is a port of the following pull request.

https://github.com/honojs/hono/pull/3415