### PR TITLE
feat(serve-static): support absolute path for `root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ import { serveStatic } from '@hono/node-server/serve-static'
 app.use('/static/*', serveStatic({ root: './' }))
 ```
 
-Note that `root` must be _relative_ to the current working directory from which the app was started. Absolute paths are not supported.
+Note that `root` must be _relative_ to the current working directory from which the app was started.
 
 This can cause confusion when running your application locally.
 

--- a/test/assets/static-absolute-root-with-dots/hello.txt
+++ b/test/assets/static-absolute-root-with-dots/hello.txt
@@ -1,0 +1,1 @@
+Hello with absolute root with dots

--- a/test/assets/static-absolute-root/hello.txt
+++ b/test/assets/static-absolute-root/hello.txt
@@ -1,0 +1,1 @@
+Hello with absolute root

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import request from 'supertest'
+import path from 'path'
 import { serveStatic } from './../src/serve-static'
 import { createAdaptorServer } from './../src/server'
 
@@ -41,6 +42,11 @@ describe('Serve Static Middleware', () => {
       root: './test/assets',
       precompressed: true,
     })
+  )
+
+  app.all(
+    '/static-absolute-root/*',
+    serveStatic({ root: path.join(path.dirname(__filename), 'assets') })
   )
 
   const server = createAdaptorServer(app)
@@ -195,5 +201,13 @@ describe('Serve Static Middleware', () => {
     expect(res.headers['content-encoding']).toBeUndefined()
     expect(res.headers['vary']).toBeUndefined()
     expect(res.text).toBe('Hello Not Compressed')
+  })
+
+  it('Should return 200 with an absolute root - /static-absolute-root/hello.txt', async () => {
+    const res = await request(server).get('/static-absolute-root/hello.txt')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8')
+    expect(res.headers['content-length']).toBe('24')
+    expect(res.text).toBe('Hello with absolute root')
   })
 })

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -49,6 +49,11 @@ describe('Serve Static Middleware', () => {
     serveStatic({ root: path.join(path.dirname(__filename), 'assets') })
   )
 
+  app.all(
+    '/static-absolute-root-with-dots/*',
+    serveStatic({ root: path.join(path.dirname(__filename), 'assets') + '/../assets' })
+  )
+
   const server = createAdaptorServer(app)
 
   it('Should return index.html', async () => {
@@ -209,5 +214,13 @@ describe('Serve Static Middleware', () => {
     expect(res.headers['content-type']).toBe('text/plain; charset=utf-8')
     expect(res.headers['content-length']).toBe('24')
     expect(res.text).toBe('Hello with absolute root')
+  })
+
+  it('Should return 200 with an absolute root with dots - /static-absolute-root-with-dots/hello.txt', async () => {
+    const res = await request(server).get('/static-absolute-root-with-dots/hello.txt')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8')
+    expect(res.headers['content-length']).toBe('34')
+    expect(res.text).toBe('Hello with absolute root with dots')
   })
 })


### PR DESCRIPTION
This PR enables the serve static to support an absolute path for the `root` option.

```ts
import { serveStatic } from '@hono/node-server'
import { serve } from '@hono/node-server/serve-static'
import { Hono } from 'hono'

const app = new Hono()
app.use('/static/*', serveStatic({ root: '/home/yusuke/app' }))

serve(app)
```

Closes #187
Related to https://github.com/honojs/hono/pull/3420