### PR TITLE
fix(serve): support ipv6 by default

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,7 @@ export const serve = (
   listeningListener?: (info: AddressInfo) => void
 ): ServerType => {
   const server = createAdaptorServer(options)
-  server.listen(options?.port ?? 3000, options.hostname ?? '0.0.0.0', () => {
+  server.listen(options?.port ?? 3000, options.hostname, () => {
     const serverInfo = server.address() as AddressInfo
     listeningListener && listeningListener(serverInfo)
   })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -909,11 +909,11 @@ describe('Memory leak test', () => {
   })
 })
 
-describe('serve',  () => { 
+describe('serve', () => {
   const app = new Hono()
   app.get('/', (c) => c.newResponse(null, 200))
   serve(app)
-  
+
   it('should serve on ipv4', async () => {
     const response = await fetch('http://localhost:3000')
     expect(response.status).toBe(200)

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -11,7 +11,7 @@ import { createServer as createHttp2Server } from 'node:http2'
 import { createServer as createHTTPSServer } from 'node:https'
 import { GlobalRequest, Request as LightweightRequest, getAbortController } from '../src/request'
 import { GlobalResponse, Response as LightweightResponse } from '../src/response'
-import { createAdaptorServer } from '../src/server'
+import { createAdaptorServer, serve } from '../src/server'
 import type { HttpBindings } from '../src/types'
 
 describe('Basic', () => {
@@ -906,5 +906,21 @@ describe('Memory leak test', () => {
     global.gc?.()
     await new Promise((resolve) => setTimeout(resolve, 10))
     expect(counter).toBe(0)
+  })
+})
+
+describe('serve',  () => { 
+  const app = new Hono()
+  app.get('/', (c) => c.newResponse(null, 200))
+  serve(app)
+  
+  it('should serve on ipv4', async () => {
+    const response = await fetch('http://localhost:3000')
+    expect(response.status).toBe(200)
+  })
+
+  it('should serve on ipv6', async () => {
+    const response = await fetch('http://[::1]:3000')
+    expect(response.status).toBe(200)
   })
 })


### PR DESCRIPTION
For node's server.listen, if no hostname param is specified it'll adaptively pick the unspecified ipv6 address (`::`) when available or the unspecified ipv4 address (`0.0.0.0`) otherwise. This fix gets rid of the behavior where we manually default to `0.0.0.0` and rely on node's underlying handling of this.

Since most modern systems should support ipv6, I also added a test case on this new behavior.

See here for the docs on node: https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback:~:text=If%20host%20is%20omitted%2C%20the%20server%20will%20accept%20connections%20on%20the%20unspecified%20IPv6%20address%20(%3A%3A)%20when%20IPv6%20is%20available%2C%20or%20the%20unspecified%20IPv4%20address%20(0.0.0.0)%20otherwise.