### PR TITLE
fix(serve-static): add error handler for decoding uri components

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -63,7 +63,14 @@ export const serveStatic = (options: ServeStaticOptions = { root: '' }): Middlew
       return next()
     }
 
-    const filename = options.path ?? decodeURIComponent(c.req.path)
+    let filename: string
+
+    try {
+      filename = options.path ?? decodeURIComponent(c.req.path)
+    } catch {
+      await options.onNotFound?.(c.req.path, c)
+      return next()
+    }
 
     let path = getFilePathWithoutDefaultDocument({
       filename: options.rewriteRequestPath ? options.rewriteRequestPath(filename) : filename,

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -152,6 +152,11 @@ describe('Serve Static Middleware', () => {
     expect(res.status).toBe(404)
   })
 
+  it('Should handle URIError thrown while decoding URI component', async () => {
+    const res = await request(server).get('/static/%c0%afsecret.txt')
+    expect(res.status).toBe(404)
+  })
+
   it('Should handle an extension less files', async () => {
     const res = await request(server).get('/static/extensionless')
     expect(res.status).toBe(200)


### PR DESCRIPTION
This PR adds an error handler for potentially thrown `URIError` during `decodeURIComponent` that should result in a HTTP 404 rather than an HTTP 500 error. 

This may happen if the encoded uri component contains an [invalid sequence encoding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent):

> [URIError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError)
Thrown if encodedURI contains a % not followed by two hexadecimal digits, or if the escape sequence does not encode a valid UTF-8 character.

Also added a test for this case 👓 