### PR TITLE
fix: TypeError: headers is not iterable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,11 +41,13 @@ export function writeFromReadableStream(stream: ReadableStream<Uint8Array>, writ
   }
 }
 
-export const buildOutgoingHttpHeaders = (headers: Headers): OutgoingHttpHeaders => {
+export const buildOutgoingHttpHeaders = (headers: Headers | Record<string, string>): OutgoingHttpHeaders => {
   const res: OutgoingHttpHeaders = {}
 
   const cookies = []
-  for (const [k, v] of headers) {
+  const entries = headers instanceof Headers ? headers.entries : Object.entries(headers);
+  
+  for (const [k, v] of entries) {
     if (k === 'set-cookie') {
       cookies.push(v)
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,12 +41,14 @@ export function writeFromReadableStream(stream: ReadableStream<Uint8Array>, writ
   }
 }
 
-export const buildOutgoingHttpHeaders = (headers: Headers | Record<string, string>): OutgoingHttpHeaders => {
+export const buildOutgoingHttpHeaders = (
+  headers: Headers | Record<string, string>
+): OutgoingHttpHeaders => {
   const res: OutgoingHttpHeaders = {}
 
   const cookies = []
-  const entries = headers instanceof Headers ? headers.entries() : Object.entries(headers);
-  
+  const entries = headers instanceof Headers ? headers.entries() : Object.entries(headers)
+
   for (const [k, v] of entries) {
     if (k === 'set-cookie') {
       cookies.push(v)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,7 +47,10 @@ export const buildOutgoingHttpHeaders = (
   const res: OutgoingHttpHeaders = {}
 
   const cookies = []
-  const entries = headers instanceof Headers ? headers.entries() : Object.entries(headers)
+  const entries =
+    headers instanceof Headers
+      ? headers.entries()
+      : Object.entries(headers).filter(([, value]) => value)
 
   for (const [k, v] of entries) {
     if (k === 'set-cookie') {
@@ -56,6 +59,7 @@ export const buildOutgoingHttpHeaders = (
       res[k] = v
     }
   }
+
   if (cookies.length > 0) {
     res['set-cookie'] = cookies
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,7 @@ export const buildOutgoingHttpHeaders = (headers: Headers | Record<string, strin
   const res: OutgoingHttpHeaders = {}
 
   const cookies = []
-  const entries = headers instanceof Headers ? headers.entries : Object.entries(headers);
+  const entries = headers instanceof Headers ? headers.entries() : Object.entries(headers);
   
   for (const [k, v] of entries) {
     if (k === 'set-cookie') {


### PR DESCRIPTION
At runtime headers may not be an `instanceof` Headers. 

This causes a lot of bugs. 

the function may get a js object as an argument. 

Instead of looping directly through `headers`, I get the entries then loop through them.
