### PR TITLE
fix: Object.entries is called with a null value

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export function writeFromReadableStream(stream: ReadableStream<Uint8Array>, writ
 }
 
 export const buildOutgoingHttpHeaders = (
-  headers: Headers | Record<string, string>
+  headers: Headers | Record<string, string | undefined> | null
 ): OutgoingHttpHeaders => {
   const res: OutgoingHttpHeaders = {}
 
@@ -50,14 +50,14 @@ export const buildOutgoingHttpHeaders = (
   const entries =
     headers instanceof Headers
       ? headers.entries()
-      : Object.entries(headers).filter(([, value]) => value)
+      : (Object.entries(headers || {}).filter(([key, value]) => key && value) as [string, string][])
 
   for (const [k, v] of entries) {
     if (k === 'set-cookie') {
       cookies.push(v)
-    } else {
-      res[k] = v
+      continue
     }
+    res[k] = v
   }
 
   if (cookies.length > 0) {


### PR DESCRIPTION
A small change to the same function. 
I am using hono with Nest.js and somehow `buildOutgoingHttpHeaders` is called with a `null` argument.


I have updated the function to address this edge case. 