### PR TITLE
fix(utils): accept HeadersInit, null, undefined in buildOutgoingHttpHeaders

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,24 +42,21 @@ export function writeFromReadableStream(stream: ReadableStream<Uint8Array>, writ
 }
 
 export const buildOutgoingHttpHeaders = (
-  headers: Headers | Record<string, string>
+  headers: Headers | HeadersInit | null | undefined
 ): OutgoingHttpHeaders => {
   const res: OutgoingHttpHeaders = {}
+  if (!(headers instanceof Headers)) {
+    headers = new Headers(headers ?? undefined)
+  }
 
   const cookies = []
-  const entries =
-    headers instanceof Headers
-      ? headers.entries()
-      : Object.entries(headers).filter(([, value]) => value)
-
-  for (const [k, v] of entries) {
+  for (const [k, v] of headers) {
     if (k === 'set-cookie') {
       cookies.push(v)
     } else {
       res[k] = v
     }
   }
-
   if (cookies.length > 0) {
     res['set-cookie'] = cookies
   }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,73 @@
+import { buildOutgoingHttpHeaders } from '../src/utils'
+
+describe('buildOutgoingHttpHeaders', () => {
+  it('original content-type is preserved', () => {
+    const headers = new Headers({
+      a: 'b',
+      'content-type': 'text/html; charset=UTF-8',
+    })
+    const result = buildOutgoingHttpHeaders(headers)
+    expect(result).toEqual({
+      a: 'b',
+      'content-type': 'text/html; charset=UTF-8',
+    })
+  })
+
+  it('multiple set-cookie', () => {
+    const headers = new Headers()
+    headers.append('set-cookie', 'a')
+    headers.append('set-cookie', 'b')
+    const result = buildOutgoingHttpHeaders(headers)
+    expect(result).toEqual({
+      'set-cookie': ['a', 'b'],
+      'content-type': 'text/plain; charset=UTF-8',
+    })
+  })
+
+  it('Headers', () => {
+    const headers = new Headers({
+      a: 'b',
+    })
+    const result = buildOutgoingHttpHeaders(headers)
+    expect(result).toEqual({
+      a: 'b',
+      'content-type': 'text/plain; charset=UTF-8',
+    })
+  })
+
+  it('Record<string, string>', () => {
+    const headers = {
+      a: 'b',
+      'Set-Cookie': 'c', // case-insensitive
+    }
+    const result = buildOutgoingHttpHeaders(headers)
+    expect(result).toEqual({
+      a: 'b',
+      'set-cookie': ['c'],
+      'content-type': 'text/plain; charset=UTF-8',
+    })
+  })
+
+  it('Record<string, string>[]', () => {
+    const headers: HeadersInit = [['a', 'b']]
+    const result = buildOutgoingHttpHeaders(headers)
+    expect(result).toEqual({
+      a: 'b',
+      'content-type': 'text/plain; charset=UTF-8',
+    })
+  })
+
+  it('null', () => {
+    const result = buildOutgoingHttpHeaders(null)
+    expect(result).toEqual({
+      'content-type': 'text/plain; charset=UTF-8',
+    })
+  })
+
+  it('undefined', () => {
+    const result = buildOutgoingHttpHeaders(undefined)
+    expect(result).toEqual({
+      'content-type': 'text/plain; charset=UTF-8',
+    })
+  })
+})


### PR DESCRIPTION
I understand that `res.headers` is not necessarily an instance of `Headers` when combined with another framework. In this kind of environment, I think it is safe to assume that it will return either HeadersInit, null, or undefined.

I think it would be better to keep the code from v1.13.3 as it is for processing the contents of the header, and to call `new Headers()` if it is not `Headers`.  The reason is as follows

* The header name is case-insensitive, so you cannot compare it directly using an Object key, such as `=== 'set-cookie'`
* The value “ should be preserved without being deleted