### PR TITLE
fix: Avoid error if connection is aborted before internal request object is created

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -85,7 +85,7 @@ const getRequestCache = Symbol('getRequestCache')
 const requestCache = Symbol('requestCache')
 const incomingKey = Symbol('incomingKey')
 const urlKey = Symbol('urlKey')
-const abortControllerKey = Symbol('abortControllerKey')
+export const abortControllerKey = Symbol('abortControllerKey')
 export const getAbortController = Symbol('getAbortController')
 
 const requestPrototype: Record<string | symbol, any> = {

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -274,6 +274,17 @@ describe('Abort request', () => {
       }
     }
   )
+
+  it('should handle request abort without requestCache', async () => {
+    const fetchCallback = async () => {
+      // NOTE: we don't req.signal
+      await new Promise(() => {}) // never resolve
+    }
+    const requestListener = getRequestListener(fetchCallback)
+    const server = createServer(requestListener)
+    const req = request(server).post('/abort').timeout({ deadline: 1 })
+    await expect(req).rejects.toHaveProperty('timeout')
+  })
 })
 
 describe('overrideGlobalObjects', () => {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -4,6 +4,7 @@ import {
   Request as LightweightRequest,
   GlobalRequest,
   getAbortController,
+  abortControllerKey,
   RequestError,
 } from '../src/request'
 
@@ -78,6 +79,21 @@ describe('Request', () => {
       expect(x).toBe(y)
       expect(z).not.toBe(x)
       expect(z).not.toBe(y)
+    })
+
+    it('should be able to safely check if an AbortController has been initialized by referencing the abortControllerKey', async () => {
+      const req = newRequest({
+        headers: {
+          host: 'localhost',
+        },
+        rawHeaders: ['host', 'localhost'],
+        url: '/foo.txt',
+      } as IncomingMessage)
+
+      expect(req[abortControllerKey]).toBeUndefined() // not initialized, do not initialize internal request object automatically
+
+      expect(req[getAbortController]()).toBeDefined()
+      expect(req[abortControllerKey]).toBeDefined() // initialized
     })
 
     it('Should throw error if host header contains path', async () => {


### PR DESCRIPTION
Fixes https://github.com/honojs/hono/issues/1695

At this time, since the user is not listening for abort events, so we should return immediately.