### PR TITLE
fix: export ServerOptions type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ type createSecureHttp2Options = {
   createServer?: typeof createSecureHttp2Server
 }
 
-type ServerOptions =
+export type ServerOptions =
   | createHttpOptions
   | createHttpsOptions
   | createHttp2Options


### PR DESCRIPTION
Makes the ServerOptions type definition publicly accessible by adding the export keyword, allowing it to be imported and used by other modules that depend on this package.