### PR TITLE
feat:add sendFile func

### DIFF
--- a/src/send-file.ts
+++ b/src/send-file.ts
@@ -1,0 +1,69 @@
+import type { Context, Env, Next } from 'hono'
+import type { StatusCode } from 'hono/utils/http-status'
+import { getMimeType } from 'hono/utils/mime'
+import { createReadStream } from 'fs'
+import { createStreamBody, getStats } from './serve-static'
+
+export const sendFile = async <E extends Env = Env>(
+    c: Context<E, string, {}>,
+    next: Next,
+    path: string,
+    options: {
+        onNotFound?: (path: string, c: Context<E>) => void | Promise<void>;
+        emptyBody?: {
+            [method: string]: StatusCode;
+        };
+    } = {
+            emptyBody: {
+                HEAD: 204,
+                OPTIONS: 204,
+            },
+        }
+) => {
+    const stats = getStats(path)
+
+    if (!stats) {
+        await options.onNotFound?.(path, c)
+        return next()
+    }
+
+    const mimeType: string = getMimeType(path) || 'application/octet-stream'
+    c.header('Content-Type', mimeType)
+
+    const size = stats.size
+
+    const { emptyBody } = options
+    if (emptyBody) {
+        for (const [k, v] of Object.entries(emptyBody)) {
+            if (k === c.req.method) {
+                c.header('Content-Length', size.toString())
+                return c.body(null, v)
+            }
+        }
+    }
+
+    const range = c.req.header('range') || ''
+
+    if (!range) {
+        c.header('Content-Length', size.toString())
+        return c.body(createStreamBody(createReadStream(path)), 200)
+    }
+
+    c.header('Accept-Ranges', 'bytes')
+    c.header('Date', stats.birthtime.toUTCString())
+
+    const parts = range.replace(/bytes=/, '').split('-', 2)
+    const start = parts[0] ? parseInt(parts[0], 10) : 0
+    let end = parts[1] ? parseInt(parts[1], 10) : stats.size - 1
+    if (size < end - start + 1) {
+        end = size - 1
+    }
+
+    const chunksize = end - start + 1
+    const stream = createReadStream(path, { start, end })
+
+    c.header('Content-Length', chunksize.toString())
+    c.header('Content-Range', `bytes ${start}-${end}/${stats.size}`)
+
+    return c.body(createStreamBody(stream), 206)
+}

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -26,7 +26,7 @@ const ENCODINGS = {
 } as const
 const ENCODINGS_ORDERED_KEYS = Object.keys(ENCODINGS) as (keyof typeof ENCODINGS)[]
 
-const createStreamBody = (stream: ReadStream) => {
+export const createStreamBody = (stream: ReadStream) => {
   const body = new ReadableStream({
     start(controller) {
       stream.on('data', (chunk) => {
@@ -48,7 +48,7 @@ const addCurrentDirPrefix = (path: string) => {
   return `./${path}`
 }
 
-const getStats = (path: string) => {
+export const getStats = (path: string) => {
   let stats: Stats | undefined
   try {
     stats = lstatSync(path)


### PR DESCRIPTION
- https://github.com/honojs/node-server/issues/205
- https://github.com/orgs/honojs/discussions/3755

exp:

```ts
import { Hono } from 'hono'
import { sendFile } from './send-file'

let tf = true
const app = new Hono()
    .get('/my-path', (c, next) => {
        tf = !tf
        const filePath: string = tf
            ? 'C:/exp/bar.gif'
            : 'C:/exp/foo.jpg'
        return sendFile(c, next, filePath)
    })
```

This project uses bun as the package manager, but uses node to run tests, so is it normal that I cannot run jest in the Windows environment?