### PR TITLE
fix: Handle Response Errors Correctly

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -224,7 +224,7 @@ export const getRequestListener = (
     }
 
     try {
-      return responseViaResponseObject(res, outgoing, options)
+      return await responseViaResponseObject(res, outgoing, options)
     } catch (e) {
       return handleResponseError(e, outgoing)
     }

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -64,6 +64,21 @@ describe('Invalid request', () => {
       expect(res.status).toBe(400)
     })
   })
+
+  describe('malformed body response', () => {
+    const malformedResponse = {
+      body: 'content'
+    };
+    const requestListener = getRequestListener(() => malformedResponse, {
+      hostname: 'example.com'
+    });
+    const server = createServer(requestListener)
+
+    it('Should return a 500 for a malformed response', async () => {
+      const res = await request(server).get('/').send()
+      expect(res.status).toBe(500)
+    })
+  });
 })
 
 describe('Error handling - sync fetchCallback', () => {

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -67,18 +67,18 @@ describe('Invalid request', () => {
 
   describe('malformed body response', () => {
     const malformedResponse = {
-      body: 'content'
-    };
+      body: 'content',
+    }
     const requestListener = getRequestListener(() => malformedResponse, {
-      hostname: 'example.com'
-    });
+      hostname: 'example.com',
+    })
     const server = createServer(requestListener)
 
     it('Should return a 500 for a malformed response', async () => {
       const res = await request(server).get('/').send()
       expect(res.status).toBe(500)
     })
-  });
+  })
 })
 
 describe('Error handling - sync fetchCallback', () => {


### PR DESCRIPTION
It looks like during a refactor this logic got changed incorrectly. You need to await the promise in this catch block. Otherwise any error thrown inside `responseViaResponseObject` won't get caught and will bubble out the top.