### PR TITLE
feat: enable to get internal "getResponseState" function at Node.js v24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "types": "./dist/conninfo.d.ts",
       "require": "./dist/conninfo.js",
       "import": "./dist/conninfo.mjs"
+    },
+    "./setup": {
+      "types": "./dist/setup.d.ts",
+      "require": "./dist/setup.js",
+      "import": "./dist/setup.mjs"
     }
   },
   "typesVersions": {

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,7 +19,7 @@ export class Response {
   #body?: BodyInit | null
   #init?: ResponseInit;
 
-  [getResponseCache](): typeof GlobalResponse {
+  [getResponseCache](): globalThis.Response {
     delete (this as any)[cacheKey]
     return ((this as any)[responseCache] ||= new GlobalResponse(this.#body, this.#init))
   }
@@ -89,7 +89,7 @@ if (!stateKey) {
 }
 
 export function getInternalBody(
-  response: Response | typeof GlobalResponse
+  response: Response | globalThis.Response
 ): InternalBody | undefined {
   if (!stateKey) {
     return

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,14 @@
+import { setGetResponseStateFn } from './utils/internal'
+
+const originalDeleteProperty = Reflect.deleteProperty
+export let getResponseState: Parameters<typeof setGetResponseStateFn>[0] | undefined
+Reflect.deleteProperty = (target, prop) => {
+  if (prop === 'getResponseState') {
+    getResponseState = (target as { getResponseState: Parameters<typeof setGetResponseStateFn>[0] })
+      .getResponseState
+    setGetResponseStateFn(getResponseState)
+    Reflect.deleteProperty = originalDeleteProperty
+  }
+  return originalDeleteProperty(target, prop)
+}
+Response

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -1,0 +1,39 @@
+export interface InternalBody {
+  source: string | Uint8Array | FormData | Blob | null
+  stream: ReadableStream
+  length: number | null
+}
+
+// XXX: share "getResponseState" function by symbols via the global object to ensure more reliable.
+let getResponseStateFn: (res: Response) => { body: InternalBody } | undefined
+const getResponseStateKey = Symbol.for('@hono/node-server/getResponseState')
+export const setGetResponseStateFn = (fn: typeof getResponseStateFn) =>
+  ((global as unknown as { [getResponseStateKey]: typeof getResponseStateFn })[
+    getResponseStateKey
+  ] = fn)
+
+// prior to v24, internal state could be obtained from the Response object via a symbol.
+if (parseInt(process.version.slice(1).split('.')[0]) < 24) {
+  const stateKey = Reflect.ownKeys(new global.Response()).find(
+    (k) => typeof k === 'symbol' && k.toString() === 'Symbol(state)'
+  ) as symbol
+  getResponseStateFn = (res) => {
+    return (res as unknown as { [stateKey: symbol]: { body: InternalBody } })[stateKey]
+  }
+}
+// after v24, internal state can only be obtained from internal function.
+
+export const getResponseState = (res: Response) => {
+  if (!getResponseStateFn) {
+    // after v24
+    getResponseStateFn = (
+      global as unknown as { [getResponseStateKey]: typeof getResponseStateFn }
+    )[getResponseStateKey]
+
+    if (!getResponseStateFn) {
+      // use "--import @hono/node-server/setup" if your app needs to optimize with internal state.
+      getResponseStateFn = () => undefined
+    }
+  }
+  return getResponseStateFn(res)
+}


### PR DESCRIPTION
fixes #240

With this PR, you will be able to apply optimisations to access internal data in v24 by executing the following.

```bash
$ node --import @hono/node-server/setup ./app.mjs
```

### What is this?

As pointed out by @timokoessler in #240, in Node.js v24.x, due to changes in https://github.com/nodejs/undici/commit/45dceeaf376325df0fee3de83bc3d9f1e82a2cfd, it is no longer possible to retrieve internal data using the previous node-server method.

Even when internal data cannot be retrieved, node-server continues to function normally; however, this may result in performance degradation for certain applications.


### Another way to get internal data

This change to ‘undici’ has made it more difficult to obtain than before, but there are ways to do so. If you execute the following code snippet in v24, you will see that it can be obtained.

```js
let getResponseState = null
const originalDeleteProperty = Reflect.deleteProperty
Reflect.deleteProperty = (target, prop) => {
  if (prop === 'getResponseState') {
    getResponseState = target.getResponseState
    Reflect.deleteProperty = originalDeleteProperty
  }
  return originalDeleteProperty(target, prop)
}

const res = new Response('Response Text')
console.log(getResponseState(res).body.source)
```


### The difficulty of making this code work

In Node.js, the Response class is dynamically initialised when `global.Response` is referenced.
This means that the code snippet above must be executed before `global.Response` is referenced for the first time. However, when executing `.mts` or `.mjs` files, `global.Response` is initialised during import resolution in most applications, so simply writing the code inside node-server will not work as expected.
To ensure that it works correctly, users must explicitly specify the `--import` option at runtime.

```bash
$ node --import @hono/node-server/setup ./app.mjs
```


### The option of giving up this optimisation

This optimisation was implemented in #145, but even without it, the speed in the ‘best case’ does not decrease. Therefore, I think there is an option to avoid making it as complex as in this PR and instead stop the optimisation that directly retrieves internal data to speed things up.

(However, if there is code that modifies the response headers, it will not achieve the ‘best case’ scenario and will remain a target for this optimisation, so I believe this optimisation applies to a fairly large number of applications.)


