### PR TITLE
perf: keep using the lightweight Response object when retrieving `headers`, `status`, and `ok`, and then drop the `getInternalBody` function.

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -49,7 +49,10 @@ const responseViaCache = (
   outgoing: ServerResponse | Http2ServerResponse
 ): undefined | Promise<undefined | void> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [status, body, header] = (res as any)[cacheKey]
+  let [status, body, header] = (res as any)[cacheKey]
+  if (header instanceof Headers) {
+    header = buildOutgoingHttpHeaders(header)
+  }
   if (typeof body === 'string') {
     header['Content-Length'] = Buffer.byteLength(body)
     outgoing.writeHead(status, header)

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -6,7 +6,7 @@ import {
   Request as LightweightRequest,
   toRequestError,
 } from './request'
-import { cacheKey, getInternalBody, Response as LightweightResponse } from './response'
+import { cacheKey, Response as LightweightResponse } from './response'
 import type { InternalCache } from './response'
 import type { CustomErrorHandler, FetchCallback, HttpBindings } from './types'
 import { writeFromReadableStream, buildOutgoingHttpHeaders } from './utils'
@@ -92,28 +92,6 @@ const responseViaResponseObject = async (
   }
 
   const resHeaderRecord: OutgoingHttpHeaders = buildOutgoingHttpHeaders(res.headers)
-
-  const internalBody = getInternalBody(res as Response)
-  if (internalBody) {
-    const { length, source, stream } = internalBody
-    if (source instanceof Uint8Array && source.byteLength !== length) {
-      // maybe `source` is detached, so we should send via res.body
-    } else {
-      // send via internal raw data
-      if (length) {
-        resHeaderRecord['content-length'] = length
-      }
-      outgoing.writeHead(res.status, resHeaderRecord)
-      if (typeof source === 'string' || source instanceof Uint8Array) {
-        outgoing.end(source)
-      } else if (source instanceof Blob) {
-        outgoing.end(new Uint8Array(await source.arrayBuffer()))
-      } else {
-        await writeFromReadableStream(stream, outgoing)
-      }
-      return
-    }
-  }
 
   if (res.body) {
     /**

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -7,6 +7,7 @@ import {
   toRequestError,
 } from './request'
 import { cacheKey, getInternalBody, Response as LightweightResponse } from './response'
+import type { InternalCache } from './response'
 import type { CustomErrorHandler, FetchCallback, HttpBindings } from './types'
 import { writeFromReadableStream, buildOutgoingHttpHeaders } from './utils'
 import { X_ALREADY_SENT } from './utils/response/constants'
@@ -49,7 +50,7 @@ const responseViaCache = (
   outgoing: ServerResponse | Http2ServerResponse
 ): undefined | Promise<undefined | void> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let [status, body, header] = (res as any)[cacheKey]
+  let [status, body, header] = (res as any)[cacheKey] as InternalCache
   if (header instanceof Headers) {
     header = buildOutgoingHttpHeaders(header)
   }
@@ -92,8 +93,7 @@ const responseViaResponseObject = async (
 
   const resHeaderRecord: OutgoingHttpHeaders = buildOutgoingHttpHeaders(res.headers)
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const internalBody = getInternalBody(res as any)
+  const internalBody = getInternalBody(res as Response)
   if (internalBody) {
     const { length, source, stream } = internalBody
     if (source instanceof Uint8Array && source.byteLength !== length) {

--- a/src/response.ts
+++ b/src/response.ts
@@ -3,12 +3,6 @@
 
 import type { OutgoingHttpHeaders } from 'node:http'
 
-interface InternalBody {
-  source: string | Uint8Array | FormData | Blob | null
-  stream: ReadableStream
-  length: number | null
-}
-
 const responseCache = Symbol('responseCache')
 const getResponseCache = Symbol('getResponseCache')
 export const cacheKey = Symbol('cache')
@@ -97,26 +91,3 @@ export class Response {
 })
 Object.setPrototypeOf(Response, GlobalResponse)
 Object.setPrototypeOf(Response.prototype, GlobalResponse.prototype)
-
-const stateKey = Reflect.ownKeys(new GlobalResponse()).find(
-  (k) => typeof k === 'symbol' && k.toString() === 'Symbol(state)'
-) as symbol | undefined
-if (!stateKey) {
-  console.warn('Failed to find Response internal state key')
-}
-
-export function getInternalBody(
-  response: Response | globalThis.Response
-): InternalBody | undefined {
-  if (!stateKey) {
-    return
-  }
-
-  if (response instanceof Response) {
-    response = (response as any)[getResponseCache]()
-  }
-
-  const state = (response as any)[stateKey] as { body?: InternalBody } | undefined
-
-  return (state && state.body) || undefined
-}

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,7 +19,7 @@ export class Response {
   #body?: BodyInit | null
   #init?: ResponseInit;
 
-  [getResponseCache](): typeof GlobalResponse {
+  [getResponseCache](): globalThis.Response {
     delete (this as any)[cacheKey]
     return ((this as any)[responseCache] ||= new GlobalResponse(this.#body, this.#init))
   }
@@ -89,7 +89,7 @@ if (!stateKey) {
 }
 
 export function getInternalBody(
-  response: Response | typeof GlobalResponse
+  response: Response | globalThis.Response
 ): InternalBody | undefined {
   if (!stateKey) {
     return

--- a/src/response.ts
+++ b/src/response.ts
@@ -46,7 +46,12 @@ export class Response {
       this.#init = init
     }
 
-    if (typeof body === 'string' || typeof (body as ReadableStream)?.getReader !== 'undefined') {
+    if (
+      typeof body === 'string' ||
+      typeof (body as ReadableStream)?.getReader !== 'undefined' ||
+      body instanceof Blob ||
+      body instanceof Uint8Array
+    ) {
       headers ||= init?.headers || { 'content-type': 'text/plain; charset=UTF-8' }
       ;(this as any)[cacheKey] = [init?.status || 200, body, headers]
     }

--- a/src/response.ts
+++ b/src/response.ts
@@ -68,18 +68,20 @@ export class Response {
     }
     return this[getResponseCache]().headers
   }
+
+  get status() {
+    return (
+      ((this as LiteResponse)[cacheKey] as InternalCache | undefined)?.[0] ??
+      this[getResponseCache]().status
+    )
+  }
+
+  get ok() {
+    const status = this.status
+    return status >= 200 && status < 300
+  }
 }
-;[
-  'body',
-  'bodyUsed',
-  'ok',
-  'redirected',
-  'status',
-  'statusText',
-  'trailers',
-  'type',
-  'url',
-].forEach((k) => {
+;['body', 'bodyUsed', 'redirected', 'statusText', 'trailers', 'type', 'url'].forEach((k) => {
   Object.defineProperty(Response.prototype, k, {
     get() {
       return this[getResponseCache]()[k]

--- a/src/response.ts
+++ b/src/response.ts
@@ -12,7 +12,7 @@ export type InternalCache = [
   string | ReadableStream,
   Record<string, string> | Headers | OutgoingHttpHeaders,
 ]
-interface LiteResponse {
+interface LightResponse {
   [responseCache]?: globalThis.Response
   [cacheKey]?: InternalCache
 }
@@ -23,8 +23,8 @@ export class Response {
   #init?: ResponseInit;
 
   [getResponseCache](): globalThis.Response {
-    delete (this as LiteResponse)[cacheKey]
-    return ((this as LiteResponse)[responseCache] ||= new GlobalResponse(this.#body, this.#init))
+    delete (this as LightResponse)[cacheKey]
+    return ((this as LightResponse)[responseCache] ||= new GlobalResponse(this.#body, this.#init))
   }
 
   constructor(body?: BodyInit | null, init?: ResponseInit) {
@@ -58,7 +58,7 @@ export class Response {
   }
 
   get headers(): Headers {
-    const cache = (this as LiteResponse)[cacheKey] as InternalCache
+    const cache = (this as LightResponse)[cacheKey] as InternalCache
     if (cache) {
       if (!(cache[2] instanceof Headers)) {
         cache[2] = new Headers(cache[2] as HeadersInit)
@@ -70,7 +70,7 @@ export class Response {
 
   get status() {
     return (
-      ((this as LiteResponse)[cacheKey] as InternalCache | undefined)?.[0] ??
+      ((this as LightResponse)[cacheKey] as InternalCache | undefined)?.[0] ??
       this[getResponseCache]().status
     )
   }

--- a/src/response.ts
+++ b/src/response.ts
@@ -34,6 +34,7 @@ export class Response {
   }
 
   constructor(body?: BodyInit | null, init?: ResponseInit) {
+    let headers: HeadersInit
     this.#body = body
     if (init instanceof Response) {
       const cachedGlobalResponse = (init as any)[responseCache]
@@ -44,16 +45,15 @@ export class Response {
         return
       } else {
         this.#init = init.#init
+        // clone headers to avoid sharing the same object between parent and child
+        headers = new Headers((init.#init as ResponseInit).headers)
       }
     } else {
       this.#init = init
     }
 
     if (typeof body === 'string' || typeof (body as ReadableStream)?.getReader !== 'undefined') {
-      const headers = (init?.headers || { 'content-type': 'text/plain; charset=UTF-8' }) as
-        | Record<string, string>
-        | Headers
-        | OutgoingHttpHeaders
+      headers ||= init?.headers || { 'content-type': 'text/plain; charset=UTF-8' }
       ;(this as any)[cacheKey] = [init?.status || 200, body, headers]
     }
   }

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http'
 import type { Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { GlobalResponse, Response as LightweightResponse } from '../src/response'
+import { GlobalResponse, Response as LightweightResponse, cacheKey } from '../src/response'
 
 Object.defineProperty(global, 'Response', {
   value: LightweightResponse,
@@ -98,5 +98,24 @@ describe('Response', () => {
       parentResponse
     )
     expect(await childResponse.text()).toEqual('HONO')
+  })
+
+  describe('Fallback to GlobalResponse object', () => {
+    it('Should return value from internal cache', () => {
+      const res = new Response('Hello! Node!')
+      res.headers.set('x-test', 'test')
+      expect(res.headers.get('x-test')).toEqual('test')
+      expect(res.status).toEqual(200)
+      expect(res.ok).toEqual(true)
+      expect(cacheKey in res).toBe(true)
+    })
+
+    it('Should return value from generated GlobalResponse object', () => {
+      const res = new Response('Hello! Node!', {
+        statusText: 'OK',
+      })
+      expect(res.statusText).toEqual('OK')
+      expect(cacheKey in res).toBe(false)
+    })
   })
 })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -107,7 +107,7 @@ describe('Basic', () => {
   })
 })
 
-describe('via response body', () => {
+describe('various response body types', () => {
   const app = new Hono()
   app.use('*', async (c, next) => {
     await next()
@@ -173,7 +173,7 @@ describe('via response body', () => {
     const res = await request(server).get('/uint8array')
     expect(res.status).toBe(200)
     expect(res.headers['content-type']).toMatch('application/octet-stream')
-    expect(res.headers['content-length']).toBeUndefined()
+    expect(res.headers['content-length']).toMatch('3')
     expect(res.body).toEqual(Buffer.from([1, 2, 3]))
   })
 
@@ -181,7 +181,7 @@ describe('via response body', () => {
     const res = await request(server).get('/blob')
     expect(res.status).toBe(200)
     expect(res.headers['content-type']).toMatch('application/octet-stream')
-    expect(res.headers['content-length']).toBeUndefined()
+    expect(res.headers['content-length']).toMatch('3')
     expect(res.body).toEqual(Buffer.from([1, 2, 3]))
   })
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -107,7 +107,7 @@ describe('Basic', () => {
   })
 })
 
-describe('via internal body', () => {
+describe('via response body', () => {
   const app = new Hono()
   app.use('*', async (c, next) => {
     await next()
@@ -173,7 +173,7 @@ describe('via internal body', () => {
     const res = await request(server).get('/uint8array')
     expect(res.status).toBe(200)
     expect(res.headers['content-type']).toMatch('application/octet-stream')
-    expect(res.headers['content-length']).toMatch('3')
+    expect(res.headers['content-length']).toBeUndefined()
     expect(res.body).toEqual(Buffer.from([1, 2, 3]))
   })
 
@@ -181,7 +181,7 @@ describe('via internal body', () => {
     const res = await request(server).get('/blob')
     expect(res.status).toBe(200)
     expect(res.headers['content-type']).toMatch('application/octet-stream')
-    expect(res.headers['content-length']).toMatch('3')
+    expect(res.headers['content-length']).toBeUndefined()
     expect(res.body).toEqual(Buffer.from([1, 2, 3]))
   })
 


### PR DESCRIPTION
This PR adopts https://github.com/usualoma/node-server/pull/3, excludes https://github.com/honojs/node-server/pull/241, and completely removes the functionality of `getInternalBody`.

### support more response body types for caching

In d72de8d, I made the optimization pattern previously covered by `getInternalBody` return from a faster cache.


### benchmark

#### script

```ts
import { serve } from '@hono/node-server'
import { Hono } from 'hono'

const app = new Hono()

app.get('/', () => {
    const res = new Response('foo')
    res.headers.set('x-foo', 'bar')
    return res
})

app.get('/uint8array', () => {
    return new Response(new Uint8Array([102, 111, 111])) // prints "foo"
})

app.get('/blob', () => {
    return new Response(new Blob([new Uint8Array([102, 111, 111])])) // prints "foo"
})

serve({
    fetch: app.fetch,
    port: 3003,
})

```

#### main branch

```
$ bombardier -d 10s --fasthttp http://localhost:3003/
Bombarding http://localhost:3003/ for 10s using 125 connection(s)
[==========================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     41208.28    6649.70   51394.11
  Latency        3.03ms     3.18ms   328.28ms
  HTTP codes:
    1xx - 0, 2xx - 411938, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     9.39MB/s
$ bombardier -d 10s --fasthttp http://localhost:3003/uint8array
Bombarding http://localhost:3003/uint8array for 10s using 125 connection(s)
[==========================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     39105.54    7149.83   48899.74
  Latency        3.19ms     1.58ms   143.78ms
  HTTP codes:
    1xx - 0, 2xx - 390974, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     8.87MB/s
$ bombardier -d 10s --fasthttp http://localhost:3003/blob
Bombarding http://localhost:3003/blob for 10s using 125 connection(s)
[==========================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     34814.79    7252.95   48210.01
  Latency        3.59ms     1.25ms    83.12ms
  HTTP codes:
    1xx - 0, 2xx - 348063, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     7.70MB/s
```

#### usualoma:feat-more-use-respose-cache-2 branch

```
$ bombardier -d 10s --fasthttp http://localhost:3003/
Bombarding http://localhost:3003/ for 10s using 125 connection(s)
[==========================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     50349.82    4485.60   61434.61
  Latency        2.48ms   412.72us    30.42ms
  HTTP codes:
    1xx - 0, 2xx - 503307, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    11.52MB/s
$ bombardier -d 10s --fasthttp http://localhost:3003/uint8array
Bombarding http://localhost:3003/uint8array for 10s using 125 connection(s)
[==========================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     49739.84    6358.60   59130.66
  Latency        2.51ms     1.68ms   143.02ms
  HTTP codes:
    1xx - 0, 2xx - 497340, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    11.29MB/s
$ bombardier -d 10s --fasthttp http://localhost:3003/blob
Bombarding http://localhost:3003/blob for 10s using 125 connection(s)
[==========================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     40411.95    6107.91   51111.33
  Latency        3.09ms     2.07ms   178.87ms
  HTTP codes:
    1xx - 0, 2xx - 403772, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     8.94MB/s
```