### PR TITLE
fix: set `RequestError` name properly

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -7,7 +7,6 @@ import { Readable } from 'node:stream'
 import type { TLSSocket } from 'node:tls'
 
 export class RequestError extends Error {
-  static name = 'RequestError'
   constructor(
     message: string,
     options?: {
@@ -15,6 +14,7 @@ export class RequestError extends Error {
     }
   ) {
     super(message, options)
+    this.name = 'RequestError'
   }
 }
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -320,3 +320,16 @@ describe('Request', () => {
     })
   })
 })
+
+describe('RequestError', () => {
+  it('should have a static name property (class name)', () => {
+    expect(RequestError.name).toBe('RequestError')
+    expect(Object.hasOwn(RequestError, 'name')).toBe(true)
+  })
+
+  it('should have an instance name property', () => {
+    const error = new RequestError('message')
+    expect(error.name).toBe('RequestError')
+    expect(Object.hasOwn(error, 'name')).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #169

We can't set the static property with `static name = 'RequestError'` in the `RequestError` class. The `name` property `RequestError` is already set.

![CleanShot 2025-05-23 at 08 02 15@2x](https://github.com/user-attachments/assets/48d630b2-c314-4ffb-a551-46e32e548886)

So, I removed it and added a setter for the instance property.
