### PR TITLE
fix: return promise from stream.cancel()

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,8 +5,7 @@ export function writeFromReadableStream(stream: ReadableStream<Uint8Array>, writ
   if (stream.locked) {
     throw new TypeError('ReadableStream is locked.')
   } else if (writable.destroyed) {
-    stream.cancel()
-    return
+    return stream.cancel()
   }
   const reader = stream.getReader()
   writable.on('close', cancel)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,6 @@
-import { buildOutgoingHttpHeaders } from '../src/utils'
+import { console } from 'node:inspector/promises'
+import { Writable } from 'node:stream'
+import { buildOutgoingHttpHeaders, writeFromReadableStream } from '../src/utils'
 
 describe('buildOutgoingHttpHeaders', () => {
   it('original content-type is preserved', () => {
@@ -69,5 +71,20 @@ describe('buildOutgoingHttpHeaders', () => {
     expect(result).toEqual({
       'content-type': 'text/plain; charset=UTF-8',
     })
+  })
+})
+
+describe('writeFromReadableStream', () => {
+  it('does handle rejections from canceled streams', async () => {
+    const stream = new ReadableStream({
+      async cancel() {
+        throw new Error('Aborted')
+      },
+    })
+
+    const destroyedWritable = new Writable()
+    destroyedWritable.destroy()
+
+    await expect(writeFromReadableStream(stream, destroyedWritable)).rejects.toThrow('Aborted')
   })
 })


### PR DESCRIPTION
The promise returned from stream.cancel() was ignored so far. This lead to unhandled promises when the stream throws during the cancel operation. In turn the whole hono node-server was shutdown.

Close #248