### PR TITLE
fix: explicitly destroy incoming stream when request ends

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -197,6 +197,8 @@ export const getRequestListener = (
         } else if (!outgoing.writableFinished) {
           req[abortControllerKey].abort('Client connection prematurely closed.')
         }
+
+        incoming.destroy()
       })
 
       res = fetchCallback(req, { incoming, outgoing } as HttpBindings) as


### PR DESCRIPTION
fixes #246

I tried various things, but I think the simplest solution is to call `incoming.destroy()` for all requests (although this only happens when `req[abortControllerKey]` is present, i.e., when a  `Request` object is generated).

https://github.com/usualoma/node-server/blob/fba40a9130b68d25602f10f002b5ddc0970c9ddc/src/request.ts#L117-L123

With this change, even in cases where the “incomplete body loading” mentioned in the following comments of the issue occurs, the server will always close the incoming socket.

* https://github.com/honojs/node-server/issues/246#issue-3177473185
* https://github.com/honojs/node-server/issues/246#issuecomment-3041205644

In existing apps, this change will cause `incoming.destroy()`, which was not explicitly called before, to be called, but I don't think it will have any effect based on my testing.