### PR TITLE
docs: separate description of autoCleanupIncoming

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ serve({
 ### `autoCleanupIncoming`
 
 The default value is `true`. The Node.js Adapter automatically cleans up (explicitly call `destroy()` method) if application is not finished to consume the incoming request. If you don't want to do that, set `false`.
+
 If the application accepts connections from arbitrary clients, this cleanup must be done otherwise incomplete requests from clients may cause the application to stop responding. If your application only accepts connections from trusted clients, such as in a reverse proxy environment and there is no process that returns a response without reading the body of the POST request all the way through, you can improve performance by setting it to `false`.
 
 ```ts


### PR DESCRIPTION
Sorry for the minor change, I wanted to split the paragraphs, but they weren't separated in the first PR.

### before

![CleanShot 2025-07-14 at 12 38 51@2x](https://github.com/user-attachments/assets/d342e123-8023-42cd-b67f-7d5116058a50)


### after

![CleanShot 2025-07-14 at 12 38 02@2x](https://github.com/user-attachments/assets/ed3b2abf-bf51-43f3-88a4-9728f4f4201b)
