### PR TITLE
feat(serve-static): support absolute path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,15 @@ jobs:
       - run: bun run lint
       - run: bun run build
       - run: bun run test
+
+  ci-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run test

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ import { serveStatic } from '@hono/node-server/serve-static'
 app.use('/static/*', serveStatic({ root: './' }))
 ```
 
-Note that `root` must be _relative_ to the current working directory from which the app was started. Absolute paths are not supported.
+If using a relative path, `root` will be relative to the current working directory from which the app was started.
 
 This can cause confusion when running your application locally.
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     }
   },
   "scripts": {
-    "test": "node --expose-gc ./node_modules/.bin/jest",
+    "test": "node --expose-gc node_modules/jest/bin/jest.js",
     "build": "tsup --external hono",
     "watch": "tsup --watch",
     "postbuild": "publint",

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -56,7 +56,7 @@ const getStats = (path: string) => {
 export const serveStatic = <E extends Env = any>(
   options: ServeStaticOptions<E> = { root: '' }
 ): MiddlewareHandler<E> => {
-  const optionRoot = options.root || '.'
+  const root = resolve(options.root || '.')
   const optionPath = options.path
 
   return async (c, next) => {
@@ -86,15 +86,14 @@ export const serveStatic = <E extends Env = any>(
     const requestPath = options.rewriteRequestPath
       ? options.rewriteRequestPath(filename, c)
       : filename
-    const rootResolved = resolve(optionRoot)
     let path: string
 
     if (optionPath) {
       // Use path option directly if specified
-      path = resolve(optionRoot, optionPath)
+      path = resolve(root, optionPath)
     } else {
       // Build with root + requestPath
-      path = resolve(join(optionRoot, requestPath))
+      path = resolve(join(root, requestPath))
     }
 
     let stats = getStats(path)
@@ -104,7 +103,7 @@ export const serveStatic = <E extends Env = any>(
       path = resolve(join(path, indexFile))
 
       // Security check: prevent path traversal attacks
-      if (!optionPath && !path.startsWith(rootResolved)) {
+      if (!optionPath && !path.startsWith(root)) {
         await options.onNotFound?.(path, c)
         return next()
       }

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -86,15 +86,12 @@ export const serveStatic = <E extends Env = any>(
     const requestPath = options.rewriteRequestPath
       ? options.rewriteRequestPath(filename, c)
       : filename
-    let path: string
 
-    if (optionPath) {
-      // Use path option directly if specified
-      path = resolve(root, optionPath)
-    } else {
-      // Build with root + requestPath
-      path = resolve(join(root, requestPath))
-    }
+    let path = optionPath
+      ? options.root
+        ? resolve(join(root, optionPath))
+        : optionPath
+      : resolve(join(root, requestPath))
 
     let stats = getStats(path)
 

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -82,6 +82,7 @@ export const serveStatic = <E extends Env = any>(
   if (options.root) {
     if (isAbsolutePath(options.root)) {
       absolutePath = true
+      optionRoot = windowsPathToUnixPath(options.root)
       optionRoot = new URL(`file://${options.root}`).pathname
     } else {
       optionRoot = options.root
@@ -89,9 +90,10 @@ export const serveStatic = <E extends Env = any>(
   }
 
   if (options.path) {
-    if (options.path.startsWith('/')) {
+    if (isAbsolutePath(options.path)) {
       absolutePath = true
-      optionPath = new URL(`file://${options.path}`).pathname
+      optionPath = windowsPathToUnixPath(options.path)
+      optionPath = new URL(`file://${optionPath}`).pathname
     } else {
       optionPath = options.path
     }
@@ -140,8 +142,6 @@ export const serveStatic = <E extends Env = any>(
 
       stats = getStats(path)
     }
-
-    path = windowsPathToUnixPath(path)
 
     if (!stats) {
       await options.onNotFound?.(path, c)

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -83,7 +83,7 @@ export const serveStatic = <E extends Env = any>(
     if (isAbsolutePath(options.root)) {
       absolutePath = true
       optionRoot = windowsPathToUnixPath(options.root)
-      optionRoot = new URL(`file://${options.root}`).pathname
+      optionRoot = new URL(`file://${optionRoot}`).pathname
     } else {
       optionRoot = options.root
     }

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -82,8 +82,7 @@ export const serveStatic = <E extends Env = any>(
   if (options.root) {
     if (isAbsolutePath(options.root)) {
       absolutePath = true
-      optionRoot = windowsPathToUnixPath(options.root)
-      optionRoot = new URL(`file://${optionRoot}`).pathname
+      optionRoot = new URL(`file://${options.root}`).pathname
     } else {
       optionRoot = options.root
     }
@@ -92,8 +91,7 @@ export const serveStatic = <E extends Env = any>(
   if (options.path) {
     if (options.path.startsWith('/')) {
       absolutePath = true
-      optionPath = windowsPathToUnixPath(options.path)
-      optionPath = new URL(`file://${optionPath}`).pathname
+      optionPath = new URL(`file://${options.path}`).pathname
     } else {
       optionPath = options.path
     }
@@ -142,6 +140,8 @@ export const serveStatic = <E extends Env = any>(
 
       stats = getStats(path)
     }
+
+    path = windowsPathToUnixPath(path)
 
     if (!stats) {
       await options.onNotFound?.(path, c)

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -91,7 +91,7 @@ export const serveStatic = <E extends Env = any>(
 
     if (optionPath) {
       // Use path option directly if specified
-      path = resolve(optionPath)
+      path = resolve(optionRoot, optionPath)
     } else {
       // Build with root + requestPath
       path = resolve(join(optionRoot, requestPath))

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -69,7 +69,7 @@ describe('Serve Static Middleware', () => {
     expect(res.text).toBe('<h1>Hello Hono</h1>')
     expect(res.headers['content-type']).toBe('text/html; charset=utf-8')
     expect(res.headers['x-custom']).toMatch(
-      /Found the file at .*\/test\/assets\/static\/index\.html$/
+      /Found the file at .*[\/\\]test[\/\\]assets[\/\\]static[\/\\]index\.html$/
     )
   })
 
@@ -170,7 +170,7 @@ describe('Serve Static Middleware', () => {
     const res = await request(server).get('/on-not-found/foo.txt')
     expect(res.status).toBe(404)
     expect(notFoundMessage).toMatch(
-      /.*\/not-found\/on-not-found\/foo\.txt is not found, request to \/on-not-found\/foo\.txt$/
+      /.*[\/\\]not-found[\/\\]on-not-found[\/\\]foo\.txt is not found, request to \/on-not-found\/foo\.txt$/
     )
   })
 

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -269,23 +269,26 @@ describe('Serve Static Middleware', () => {
       path.join(__dirname, 'assets'),
       __dirname + path.sep + '..' + path.sep + 'test' + path.sep + 'assets',
     ]
+    const optionPaths = ['favicon.ico', '/favicon.ico']
     rootPaths.forEach((root) => {
-      describe(root, () => {
-        const app = new Hono()
-        const server = createAdaptorServer(app)
+      optionPaths.forEach((optionPath) => {
+        describe(`${root} + ${optionPath}`, () => {
+          const app = new Hono()
+          const server = createAdaptorServer(app)
 
-        app.use(
-          '/favicon.ico',
-          serveStatic({
-            root: './test/assets',
-            path: 'favicon.ico',
+          app.use(
+            '/favicon.ico',
+            serveStatic({
+              root,
+              path: optionPath,
+            })
+          )
+
+          it('Should return 200 response if both root and path set', async () => {
+            const res = await request(server).get('/favicon.ico')
+            expect(res.status).toBe(200)
+            expect(res.headers['content-type']).toBe('image/x-icon')
           })
-        )
-
-        it('Should return 200 response if both root and path set', async () => {
-          const res = await request(server).get('/favicon.ico')
-          expect(res.status).toBe(200)
-          expect(res.headers['content-type']).toBe('image/x-icon')
         })
       })
     })

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -236,14 +236,14 @@ describe('Serve Static Middleware', () => {
         app.use('/static/*', serveStatic({ root }))
         app.use('/favicon.ico', serveStatic({ path: root + '/favicon.ico' }))
 
-        it(`Should return index.html`, async () => {
+        it('Should return index.html', async () => {
           const res = await request(server).get('/static')
           expect(res.status).toBe(200)
           expect(res.headers['content-type']).toBe('text/html; charset=utf-8')
           expect(res.text).toBe('<h1>Hello Hono</h1>')
         })
 
-        it(`Should return correct headers and data for text`, async () => {
+        it('Should return correct headers and data for text', async () => {
           const res = await request(server).get('/static/plain.txt')
           expect(res.status).toBe(200)
           expect(res.headers['content-type']).toBe('text/plain; charset=utf-8')

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -68,7 +68,9 @@ describe('Serve Static Middleware', () => {
     expect(res.status).toBe(200)
     expect(res.text).toBe('<h1>Hello Hono</h1>')
     expect(res.headers['content-type']).toBe('text/html; charset=utf-8')
-    expect(res.headers['x-custom']).toMatch(/Found the file at .*\/test\/assets\/static\/index\.html$/)
+    expect(res.headers['x-custom']).toMatch(
+      /Found the file at .*\/test\/assets\/static\/index\.html$/
+    )
   })
 
   it('Should return hono.html', async () => {

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -263,6 +263,34 @@ describe('Serve Static Middleware', () => {
     })
   })
 
+  describe('Root and path combination tests', () => {
+    const rootPaths = [
+      path.join(__dirname, 'assets'),
+      path.join(__dirname, 'assets'),
+      __dirname + path.sep + '..' + path.sep + 'test' + path.sep + 'assets',
+    ]
+    rootPaths.forEach((root) => {
+      describe(root, () => {
+        const app = new Hono()
+        const server = createAdaptorServer(app)
+
+        app.use(
+          '/favicon.ico',
+          serveStatic({
+            root: './test/assets',
+            path: 'favicon.ico',
+          })
+        )
+
+        it('Should return 200 response if both root and path set', async () => {
+          const res = await request(server).get('/favicon.ico')
+          expect(res.status).toBe(200)
+          expect(res.headers['content-type']).toBe('image/x-icon')
+        })
+      })
+    })
+  })
+
   describe('Security tests', () => {
     const app = new Hono()
     const server = createAdaptorServer(app)

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -228,13 +228,16 @@ describe('Serve Static Middleware', () => {
   })
 
   describe('Absolute path', () => {
-    const rootPaths = [path.join(__dirname, 'assets'), __dirname + '/../test/assets']
+    const rootPaths = [
+      path.join(__dirname, 'assets'),
+      __dirname + path.sep + '..' + path.sep + 'test' + path.sep + 'assets',
+    ]
     rootPaths.forEach((root) => {
       describe(root, () => {
         const app = new Hono()
         const server = createAdaptorServer(app)
         app.use('/static/*', serveStatic({ root }))
-        app.use('/favicon.ico', serveStatic({ path: root + '/favicon.ico' }))
+        app.use('/favicon.ico', serveStatic({ path: root + path.sep + 'favicon.ico' }))
 
         it('Should return index.html', async () => {
           const res = await request(server).get('/static')


### PR DESCRIPTION
Fixies #187
Related to #203  #238

This PR enables serve-static to support absolute paths, but both `root` and `path` options.

I considered that we should move the serve-static feature to the main `honojs/hono` core related to #203 https://github.com/honojs/hono/issues/3483. However, if so, we need to update the peer dependencies for `hono` so that we can add this feature to this project separately from `honojs/hono`.
