### PR TITLE
fix: handle client disconnection without canceling stream

### DIFF
--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,5 @@
-import { buildOutgoingHttpHeaders } from '../src/utils'
+import { Writable } from 'node:stream'
+import { buildOutgoingHttpHeaders, writeFromReadableStream } from '../src/utils'
 
 describe('buildOutgoingHttpHeaders', () => {
   it('original content-type is preserved', () => {
@@ -69,5 +70,43 @@ describe('buildOutgoingHttpHeaders', () => {
     expect(result).toEqual({
       'content-type': 'text/plain; charset=UTF-8',
     })
+  })
+})
+
+describe('writeFromReadableStream', () => {
+  it('should handle client disconnection gracefully without canceling stream', async () => {
+    let enqueueCalled = false
+    let cancelCalled = false
+
+    // Create test ReadableStream
+    const stream = new ReadableStream({
+      start(controller) {
+        setTimeout(() => {
+          try {
+            controller.enqueue(new TextEncoder().encode('test'))
+            enqueueCalled = true
+          } catch {
+            // Test should fail if error occurs
+          }
+          controller.close()
+        }, 100)
+      },
+      cancel() {
+        cancelCalled = true
+      },
+    })
+
+    // Test Writable stream
+    const writable = new Writable()
+
+    // Simulate client disconnection after 50ms
+    setTimeout(() => {
+      writable.destroy()
+    }, 50)
+
+    await writeFromReadableStream(stream, writable)
+
+    expect(enqueueCalled).toBe(true) // enqueue should succeed
+    expect(cancelCalled).toBe(false) // cancel should not be called
   })
 })


### PR DESCRIPTION
Currently, if the client disconnects, the response stream will be canceled immediately:

https://github.com/honojs/node-server/blob/b5663ebfd7d6693fca2755c4f10d973d96eb9368/src/utils.ts#L8

https://github.com/honojs/node-server/blob/b5663ebfd7d6693fca2755c4f10d973d96eb9368/src/utils.ts#L21

I'm wondering what the correct behavior is in this situation, but it causes #239. To fix it, it should handle client disconnection gracefully.

Referring to https://github.com/hi-ogawa/reproductions/tree/main/web-to-node-handler-body-cancel, the behavior of `@mjackson/node-fetch-server` is different. With this PR, `@hono/node-server` behaves the same as it.

Fixes #239