### PR TITLE
improve serve-static function

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -72,7 +72,7 @@ export const serveStatic = <E extends Env = any>(
       // Prevent encoded path traversal attacks
       if (!optionPath) {
         const decodedPath = decodeURIComponent(rawPath)
-        if (decodedPath.includes('..')) {
+        if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(decodedPath)) {
           await options.onNotFound?.(rawPath, c)
           return next()
         }

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -2,7 +2,7 @@ import type { Context, Env, MiddlewareHandler } from 'hono'
 import { getMimeType } from 'hono/utils/mime'
 import type { ReadStream, Stats } from 'node:fs'
 import { createReadStream, lstatSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 
 export type ServeStaticOptions<E extends Env = Env> = {
   /**
@@ -56,7 +56,7 @@ const getStats = (path: string) => {
 export const serveStatic = <E extends Env = any>(
   options: ServeStaticOptions<E> = { root: '' }
 ): MiddlewareHandler<E> => {
-  const root = resolve(options.root || '.')
+  const root = options.root || ''
   const optionPath = options.path
 
   return async (c, next) => {
@@ -67,44 +67,30 @@ export const serveStatic = <E extends Env = any>(
 
     let filename: string
 
-    try {
-      const rawPath = optionPath ?? c.req.path
-      // Prevent encoded path traversal attacks
-      if (!optionPath) {
-        const decodedPath = decodeURIComponent(rawPath)
-        if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(decodedPath)) {
-          await options.onNotFound?.(rawPath, c)
-          return next()
+    if (optionPath) {
+      filename = optionPath
+    } else {
+      try {
+        filename = decodeURIComponent(c.req.path)
+        if (/(?:^|[\/\\])\.\.(?:$|[\/\\])/.test(filename)) {
+          throw new Error()
         }
+      } catch {
+        await options.onNotFound?.(c.req.path, c)
+        return next()
       }
-      filename = optionPath ?? decodeURIComponent(c.req.path)
-    } catch {
-      await options.onNotFound?.(c.req.path, c)
-      return next()
     }
 
-    const requestPath = options.rewriteRequestPath
-      ? options.rewriteRequestPath(filename, c)
-      : filename
-
-    let path = optionPath
-      ? options.root
-        ? resolve(join(root, optionPath))
-        : optionPath
-      : resolve(join(root, requestPath))
+    let path = join(
+      root,
+      !optionPath && options.rewriteRequestPath ? options.rewriteRequestPath(filename, c) : filename
+    )
 
     let stats = getStats(path)
 
     if (stats && stats.isDirectory()) {
       const indexFile = options.index ?? 'index.html'
-      path = resolve(join(path, indexFile))
-
-      // Security check: prevent path traversal attacks
-      if (!optionPath && !path.startsWith(root)) {
-        await options.onNotFound?.(path, c)
-        return next()
-      }
-
+      path = join(path, indexFile)
       stats = getStats(path)
     }
 

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -318,5 +318,10 @@ describe('Serve Static Middleware', () => {
       const res = await request(server).get('/static/%2e%2e%2fsecret.txt')
       expect(res.status).toBe(404)
     })
+
+    it('Should accept filename with double dots', async () => {
+      const res = await request(server).get('/static/foo..bar.txt')
+      expect(res.status).toBe(200)
+    })
   })
 })

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -69,7 +69,7 @@ describe('Serve Static Middleware', () => {
     expect(res.text).toBe('<h1>Hello Hono</h1>')
     expect(res.headers['content-type']).toBe('text/html; charset=utf-8')
     expect(res.headers['x-custom']).toMatch(
-      /Found the file at .*[\/\\]test[\/\\]assets[\/\\]static[\/\\]index\.html$/
+      /Found the file at test[\/\\]assets[\/\\]static[\/\\]index\.html$/
     )
   })
 
@@ -170,7 +170,7 @@ describe('Serve Static Middleware', () => {
     const res = await request(server).get('/on-not-found/foo.txt')
     expect(res.status).toBe(404)
     expect(notFoundMessage).toMatch(
-      /.*[\/\\]not-found[\/\\]on-not-found[\/\\]foo\.txt is not found, request to \/on-not-found\/foo\.txt$/
+      /not-found[\/\\]on-not-found[\/\\]foo\.txt is not found, request to \/on-not-found\/foo\.txt$/
     )
   })
 


### PR DESCRIPTION
### fix: enable to serve filename with double dots

As described in the hono core, filenames such as `foo..bar.txt` should be accepted.

https://github.com/honojs/hono/blob/530ab09ae10caf33903dfb677dff239df01d5ded/src/utils/filepath.test.ts#L13-L17


### refactor: simplify serve-static() function

#### Security check

Since the only untrusted string is `c.req.path`, I think the check should only be done in the following location.

https://github.com/honojs/node-server/compare/main...usualoma:node-server:refactor-serve-static?expand=1#diff-85001ab5aae1b04893fe64f90842d5e368e62920e6655ccc1792aa4dff852794R73-R80

I don't think any invalid strings will be entered here.

https://github.com/honojs/node-server/compare/main...usualoma:node-server:refactor-serve-static?expand=1#diff-85001ab5aae1b04893fe64f90842d5e368e62920e6655ccc1792aa4dff852794L102-L106


#### Stop calling `resolve()`

If security checks have been completed, I don't think it's necessary to call `resolve()` in `serveStatic()`.