### PR TITLE
fix(listener): In Node.js v24, some response bodies are not read to the end until the next task queue.

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -139,6 +139,14 @@ const responseViaResponseObject = async (
         done = true
       })
       if (!chunk) {
+        if (i === 1 && resHeaderRecord['transfer-encoding'] !== 'chunked') {
+          // XXX: In Node.js v24, some response bodies are not read all the way through until the next task queue,
+          // so wait a moment and retry. (e.g. new Blob([new Uint8Array(contents)]) )
+          await new Promise((resolve) => setTimeout(resolve))
+          i--
+          continue
+        }
+
         // Error occurred or currentReadPromise is not yet resolved.
         // If an error occurs, immediately break the loop.
         // If currentReadPromise is not yet resolved, pass it to writeFromReadableStreamDefaultReader.


### PR DESCRIPTION
Fixes #264

I considered making the following additional commit, but since it would change the behavior a bit and I am concerned about the performance impact (and, in fact, the need to deal with more case-sensitive parts), I would like to complete the fix with only the first commit and not add anything in particular.

https://github.com/usualoma/node-server/compare/fix-wait-next-task-node24...usualoma:node-server:fix-wait-next-task-node24-2