### PR TITLE
fix(listener): Limit retries to a maximum of three.

### DIFF
--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -323,7 +323,6 @@ describe('various response body types', () => {
       const resPromise = request(server)
         .get('/event-stream-without-transfer-encoding')
         .parse((res, fn) => {
-          
           res.on('data', (chunk) => {
             const str = chunk.toString()
             expect(str).toBe(expectedChunks.shift())


### PR DESCRIPTION
fixes #266

If the application did not include `Transfer-Encoding: chunked`, depending on the timing of enqueue, it would loop indefinitely until the second chunk was read.

One way to do this is to treat `text/event-stream` as special, as @yusukebe pointed out in this comment, but I would prefer to resolve this without depending on a specific `Content-Type`.

https://github.com/honojs/node-server/pull/265#discussion_r2241271562

Essentially, the problem was simply [#265](https://github.com/honojs/node-server/pull/265)'s `i--` and `currentReadPromise = reader.read()`, so I think that fixing that should be sufficient without any additional logical changes.

### Minimal reproducible example

https://github.com/usualoma/hono-se-266