### PR TITLE
feat(request): support `x-forwarded-proto` header for protocol detection

### DIFF
--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -354,6 +354,24 @@ describe('Request', () => {
         expect(req).toBeInstanceOf(GlobalRequest)
         expect(req.url).toBe('https://localhost/foo.txt')
       })
+
+      it('should prioritize encrypted socket over x-forwarded-proto header', async () => {
+        const socket = new Socket() as TLSSocket
+        socket.encrypted = true
+        const req = newRequest(
+          // @ts-expect-error x-forwarded-proto is not in IncomingHttpHeaders
+          {
+            socket,
+            headers: {
+              host: 'localhost',
+              'x-forwarded-proto': 'http', // This should be ignored
+            },
+            url: '/foo.txt',
+          }
+        )
+        expect(req).toBeInstanceOf(GlobalRequest)
+        expect(req.url).toBe('https://localhost/foo.txt') // Should be https despite header
+      })
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/honojs/node-server/issues/146#issuecomment-3052968918