### PR TITLE
fix: Keep lightweight request even if accessing method, url or headers

### DIFF
--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -35,6 +35,27 @@ describe('Request', () => {
       expect(req.keepalive).toBe(false)
     })
 
+    it('Should not generate GlobalRequest when accessing method, url or headers', async () => {
+      const req = newRequest({
+        method: 'GET',
+        url: '/',
+        headers: {
+          host: 'localhost',
+        },
+        rawHeaders: ['host', 'localhost'],
+      } as IncomingMessage)
+
+      // keep lightweight request even if accessing method, url or headers
+      expect(req.method).toBe('GET')
+      expect(req.url).toBe('http://localhost/')
+      expect(req.headers.get('host')).toBe('localhost')
+      expect(req[abortControllerKey]).toBeUndefined()
+
+      // generate GlobalRequest
+      expect(req.keepalive).toBe(false)
+      expect(req[abortControllerKey]).toBeDefined()
+    })
+
     it('Should resolve double dots in URL', async () => {
       const req = newRequest({
         headers: {


### PR DESCRIPTION
#269

### What is this?

Stop generating heavy `global.Request` just by accessing `req.headers`.

This eliminates the memory consumption that until now was caused by simply applying the simple middleware called `cors()`, which generated a `global.Request` and was hard to free up until `GC` was executed.

### Cases not resolved

In situations where we accept a lot of lightweight POST requests, this pull request will not improve on memory usage.