### PR TITLE
fix: better handle range parse to avoid NaN error

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -149,8 +149,8 @@ export const serveStatic = <E extends Env = any>(
     c.header('Date', stats.birthtime.toUTCString())
 
     const parts = range.replace(/bytes=/, '').split('-', 2)
-    const start = parts[0] ? parseInt(parts[0], 10) : 0
-    let end = parts[1] ? parseInt(parts[1], 10) : stats.size - 1
+    const start = parseInt(parts[0] ?? "", 10) || 0
+    let end = parseInt(parts[1], 10) || size - 1
     if (size < end - start + 1) {
       end = size - 1
     }


### PR DESCRIPTION
when sending a invalid `range` header to serveStatic, you may get the following error:

```
 {
  error: 'The value of "start" is out of range. It must be an integer. Received NaN',
  stack: 'RangeError [ERR_OUT_OF_RANGE]: The value of "start" is out of range. It must be an integer. Received NaN\n' +
    '    at new ReadStream (node:internal/fs/streams:207:5)\n' +
    '    at createReadStream (node:fs:3159:10)\n' +
    '    at <anonymous> (/app/node_modules/@hono/node-server/dist/serve-static.mjs:115:20)\n' +
  method: 'GET',
  path: '/static',
  userAgent: 'curl/8.7.1'
}
```

for example, i send the following request to get a static file:

```bash
curl -H 'range: hello' http://example.com/static
```

This PR improves the handling of the `parseInt` function by defaulting to `0` whenever error occurred.