### PR TITLE
fix: Refactor promise check for response handling

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -103,7 +103,7 @@ const responseViaResponseObject = async (
   outgoing: ServerResponse | Http2ServerResponse,
   options: { errorHandler?: CustomErrorHandler } = {}
 ) => {
-  if (typeof res.then === 'function') {
+  if ("then" in res && typeof res.then === 'function') {
     if (options.errorHandler) {
       try {
         res = await res

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -103,7 +103,7 @@ const responseViaResponseObject = async (
   outgoing: ServerResponse | Http2ServerResponse,
   options: { errorHandler?: CustomErrorHandler } = {}
 ) => {
-  if (res instanceof Promise) {
+  if (typeof res.then === 'function') {
     if (options.errorHandler) {
       try {
         res = await res

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -98,12 +98,15 @@ const responseViaCache = async (
   ;(outgoing as OutgoingHasOutgoingEnded)[outgoingEnded]?.()
 }
 
+const isPromise = (res: Response | Promise<Response>): res is Promise<Response> =>
+  typeof (res as Promise<Response>).then === 'function'
+
 const responseViaResponseObject = async (
   res: Response | Promise<Response>,
   outgoing: ServerResponse | Http2ServerResponse,
   options: { errorHandler?: CustomErrorHandler } = {}
 ) => {
-  if ("then" in res && typeof res.then === 'function') {
+  if (isPromise(res)) {
     if (options.errorHandler) {
       try {
         res = await res


### PR DESCRIPTION
I got an error because `instanceof` wouldn't recognize `res` as a `Promise`. 

Might be related to my usage of `tsx`, idk if it breaks the prototype chain or something.

Anyway, if I change to check for a `then` method, everything works again.