### PR TITLE
fix: cancel a readable stream if a writable stream is closed before a readable stream is closed.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,15 +12,17 @@ export function writeFromReadableStreamDefaultReader(
   writable: Writable,
   currentReadPromise?: Promise<ReadableStreamReadResult<Uint8Array>> | undefined
 ) {
-  const handleError = () => {
-    // ignore the error
+  const cancel = (error?: unknown) => {
+    reader.cancel(error).catch(() => {})
   }
 
-  writable.on('error', handleError)
+  writable.on('close', cancel)
+  writable.on('error', cancel)
   ;(currentReadPromise ?? reader.read()).then(flow, handleStreamError)
 
   return reader.closed.finally(() => {
-    writable.off('error', handleError)
+    writable.off('close', cancel)
+    writable.off('error', cancel)
   })
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
fix: #279

There may be compatibility issues with other frameworks or existing implementations on different servers; however, calling `cancel()` appears to be the correct approach according to web standards.