### PR TITLE
[WIP] feat: introduce `hono-node-server` script to serve Hono app

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Node.js Adapter for Hono",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "hono-node-server": "./dist/serve.js"
+  },
   "files": [
     "dist"
   ],

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,0 +1,27 @@
+import { realpathSync } from 'node:fs'
+import { parseArgs } from 'node:util'
+import { serve } from './server'
+
+const { values, positionals } = parseArgs({
+  options: {
+    port: { type: 'string' },
+  },
+  allowPositionals: true,
+})
+
+if (positionals.length === 0) {
+  throw new Error('Please specify the path to the app file.')
+}
+
+const appFilePath = realpathSync(positionals[0])
+import(appFilePath).then(({ default: app }) => {
+  serve(
+    {
+      fetch: app.fetch,
+      port: values.port ? Number.parseInt(values.port) : undefined,
+    },
+    (info) => {
+      console.log(`Listening on http://localhost:${info.port}`)
+    }
+  )
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,10 +1,21 @@
 import { defineConfig } from 'tsup'
+import type { Options } from 'tsup'
 
-export default defineConfig({
-  entry: ['./src/**/*.ts'],
+const options: Options = {
   format: ['esm', 'cjs'],
   dts: true,
   splitting: false,
   sourcemap: false,
   clean: true,
-})
+}
+export default defineConfig([
+  {
+    entry: ['./src/**/*.ts', '!./src/serve.ts'],
+    ...options,
+  },
+  {
+    entry: ['./src/serve.ts'],
+    ...options,
+    banner: { js: '#!/usr/bin/env node' },
+  },
+])


### PR DESCRIPTION
Starting with Node.js v24, experimental-strip-types is enabled by default. This allows us to run an app built with Hono in .ts format using very simple code and without external dependencies, simply by adding this PR.

While there are limitations, I find it convenient that you can run it in Node.js simply by changing the command, using exactly the same code as Deno or Bun.

```bash
$ cat app.ts
import { Hono } from 'hono'

const app = new Hono()
app.get('/', async (c) => {
  return c.json({ message: 'Hello World' })
})

export default app

$ npx @hono/node-server app.ts
Listening on http://localhost:3000
```