### PR TITLE
feat: introduce new option requestsPerForcedGC

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ export const createAdaptorServer = (options: Options): ServerType => {
     hostname: options.hostname,
     overrideGlobalObjects: options.overrideGlobalObjects,
     autoCleanupIncoming: options.autoCleanupIncoming,
+    requestsPerForcedGC: options.requestsPerForcedGC,
   })
   // ts will complain about createServerHTTP and createServerHTTP2 not being callable, which works just fine
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export type Options = {
   fetch: FetchCallback
   overrideGlobalObjects?: boolean
   autoCleanupIncoming?: boolean
+  requestsPerForcedGC?: number
   port?: number
   hostname?: string
 } & ServerOptions


### PR DESCRIPTION
Normally, this setting is not required, but for environments where GC execution is expected to be delayed, an option has been added to explicitly trigger GC every N requests.

#### app

```ts
import { Hono } from 'hono'
import { serve } from '@hono/node-server' 

const app = new Hono()

app.get('/', (c) => c.text('OK'))

serve(
  {
    fetch: app.fetch,
    requestsPerForcedGC: 1000, // Explicitly trigger garbage collection every 1000 requests.
  },
  (info) => {
    console.log(`Server is running on http://localhost:${info.port}`)
  }
)
```

#### runner

```bash
$ node --expose-gc dist/index.js
```