### PR TITLE
docs: add guide for listening to UNIX domain socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,23 @@ app.get('/', (c) => {
 serve(app)
 ```
 
+## Listen to a UNIX domain socket
+
+You can configure the HTTP server to listen to a UNIX domain socket instead of a TCP port.
+
+```ts
+import { createAdaptorServer } from '@hono/node-server'
+
+// ...
+
+const socketPath ='/tmp/example.sock'
+
+const server = createAdaptorServer(app)
+server.listen(socketPath, () => {
+  console.log(`Listening on ${socketPath}`)
+})
+```
+
 ## Related projects
 
 - Hono - <https://hono.dev>


### PR DESCRIPTION
This PR fixes #89.

Since there are no plans to add an option for listening on UNIX domain sockets, I think we can add a note to the README explaining this.

Thanks to @odanado for providing the code snippet.