### PR TITLE
fix(globals): Stop overwriting global.fetch

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,19 +1,6 @@
 import crypto from 'node:crypto'
 
-const webFetch = global.fetch
-
 /** jest dose not use crypto in the global, but this is OK for node 18 */
 if (typeof global.crypto === 'undefined') {
   global.crypto = crypto as Crypto
-}
-
-global.fetch = (info, init?) => {
-  init = {
-    // Disable compression handling so people can return the result of a fetch
-    // directly in the loader without messing with the Content-Encoding header.
-    compress: false,
-    ...init,
-  } as RequestInit
-
-  return webFetch(info as RequestInfo, init)
 }


### PR DESCRIPTION
fix #294

`compress: false` was added below.

https://github.com/honojs/node-server/pull/41

This is likely for compatibility with the compress option when using node-fetch.

https://www.npmjs.com/package/node-fetch

The compress option is not used with the Fetch API.

https://developer.mozilla.org/docs/Web/API/RequestInit

Since we no longer need to consider the use of node-fetch in the current version of node-server, I believe we can stop overriding `global.fetch`.
