### PR TITLE
fix: do not overwrite Content-Length in the fast path pattern if Content-Length already exists.

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -77,6 +77,10 @@ const responseViaCache = async (
   } else if (header instanceof Headers) {
     hasContentLength = header.has('content-length')
     header = buildOutgoingHttpHeaders(header)
+  } else if (Array.isArray(header)) {
+    const headerObj = new Headers(header)
+    hasContentLength = headerObj.has('content-length')
+    header = buildOutgoingHttpHeaders(headerObj)
   } else {
     for (const key in header) {
       if (key.length === 14 && key.toLowerCase() === 'content-length') {

--- a/src/response.ts
+++ b/src/response.ts
@@ -10,7 +10,7 @@ export const cacheKey = Symbol('cache')
 export type InternalCache = [
   number,
   string | ReadableStream,
-  Record<string, string> | Headers | OutgoingHttpHeaders | undefined,
+  Record<string, string> | [string, string][] | Headers | OutgoingHttpHeaders | undefined,
 ]
 interface LightResponse {
   [responseCache]?: globalThis.Response

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -254,6 +254,25 @@ describe('various response body types', () => {
         })
         return response
       })
+      app.get('/text-with-content-length-array', () => {
+        const response = new Response('Hello Hono!', {
+          headers: [
+            ['content-type', 'text/plain'],
+            ['content-length', '00011'],
+          ],
+        })
+        return response
+      })
+      app.get('/text-with-set-cookie-array', () => {
+        const response = new Response('Hello Hono!', {
+          headers: [
+            ['content-type', 'text/plain'],
+            ['set-cookie', 'a=1'],
+            ['set-cookie', 'b=2'],
+          ],
+        })
+        return response
+      })
 
       app.use('/etag/*', etag())
       app.get('/etag/buffer', () => {
@@ -397,6 +416,22 @@ describe('various response body types', () => {
       expect(res.status).toBe(200)
       expect(res.headers['content-type']).toMatch('text/plain')
       expect(res.headers['content-length']).toBe('00011')
+      expect(res.text).toBe('Hello Hono!')
+    })
+
+    it('Should return 200 response - GET /text-with-content-length-array', async () => {
+      const res = await request(server).get('/text-with-content-length-array')
+      expect(res.status).toBe(200)
+      expect(res.headers['content-type']).toMatch('text/plain')
+      expect(res.headers['content-length']).toBe('00011')
+      expect(res.text).toBe('Hello Hono!')
+    })
+
+    it('Should return 200 response - GET /text-with-set-cookie-array', async () => {
+      const res = await request(server).get('/text-with-set-cookie-array')
+      expect(res.status).toBe(200)
+      expect(res.headers['content-type']).toMatch('text/plain')
+      expect(res.headers['set-cookie']).toEqual(['a=1', 'b=2'])
       expect(res.text).toBe('Hello Hono!')
     })
 


### PR DESCRIPTION
fixes #308

This PR contains two fixes related to the lightweight Response fast path.

### For 7cfd1e37fac78b1f0c33760d9c43503e135e3bd8

* It now checks whether `content-length` is already present before setting Content-Length.
* It is particularly optimized for cases where no header is specified at all. (for example, `new Response('text')`)
* The literal `{ 'content-type': 'text/plain; charset=UTF-8' }` now appears in two places. This duplication is intentional: we prioritize performance in the fast path over deduplication here.

### For 46ebb313c62070f39537a01b834285e7e21487dc

* Tuple-style headers ([string, string][]) were not handled in responseViaCache before.
* Creating a `new Headers(...)` instance is relatively expensive, but this header style is expected to be very rare in practice, so we accept this tradeoff to keep the implementation simple.