### PR TITLE
perf: improve body read performance

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -4,7 +4,7 @@ import type { Http2ServerResponse } from 'node:http2'
 import type { Writable } from 'node:stream'
 import type { IncomingMessageWithWrapBodyStream } from './request'
 import {
-  abortControllerKey,
+  abortRequest,
   newRequest,
   Request as LightweightRequest,
   wrapBodyStream,
@@ -260,13 +260,14 @@ export const getRequestListener = (
 
       // Detect if request was aborted.
       outgoing.on('close', () => {
-        const abortController = req[abortControllerKey] as AbortController | undefined
-        if (abortController) {
-          if (incoming.errored) {
-            req[abortControllerKey].abort(incoming.errored.toString())
-          } else if (!outgoing.writableFinished) {
-            req[abortControllerKey].abort('Client connection prematurely closed.')
-          }
+        let abortReason: string | undefined
+        if (incoming.errored) {
+          abortReason = incoming.errored.toString()
+        } else if (!outgoing.writableFinished) {
+          abortReason = 'Client connection prematurely closed.'
+        }
+        if (abortReason !== undefined) {
+          req[abortRequest](abortReason)
         }
 
         // incoming is not consumed to the end

--- a/src/request.ts
+++ b/src/request.ts
@@ -22,6 +22,15 @@ export const GlobalRequest = global.Request
 export class Request extends GlobalRequest {
   constructor(input: string | Request, options?: RequestInit) {
     if (typeof input === 'object' && getRequestCache in input) {
+      // Match native Request behavior:
+      // constructing from a consumed Request is allowed only when init.body is non-null.
+      const hasReplacementBody =
+        options !== undefined && 'body' in options && (options as RequestInit).body != null
+      if ((input as any)[bodyConsumedDirectlyKey] && !hasReplacementBody) {
+        throw new TypeError(
+          'Cannot construct a Request with a Request object that has already been used.'
+        )
+      }
       input = (input as any)[getRequestCache]()
     }
     // Check if body is ReadableStream like. This makes it compatbile with ReadableStream polyfills.
@@ -115,20 +124,249 @@ const urlKey = Symbol('urlKey')
 const headersKey = Symbol('headersKey')
 export const abortControllerKey = Symbol('abortControllerKey')
 export const getAbortController = Symbol('getAbortController')
+export const abortRequest = Symbol('abortRequest')
 const bodyBufferKey = Symbol('bodyBuffer')
+const bodyReadPromiseKey = Symbol('bodyReadPromise')
+const bodyConsumedDirectlyKey = Symbol('bodyConsumedDirectly')
+const bodyLockReaderKey = Symbol('bodyLockReader')
+const abortReasonKey = Symbol('abortReason')
 
-const readBodyDirect = (incoming: IncomingMessage | Http2ServerRequest): Promise<Buffer> => {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = []
-    incoming.on('data', (chunk: Buffer) => chunks.push(chunk))
-    incoming.on('end', () => resolve(chunks.length === 1 ? chunks[0] : Buffer.concat(chunks)))
-    incoming.on('error', reject)
+const throwBodyUnusable = (): never => {
+  throw new TypeError('Body is unusable')
+}
+
+const rejectBodyUnusable = (): Promise<never> => {
+  return Promise.reject(throwBodyUnusable())
+}
+
+const textDecoder = new TextDecoder()
+
+const consumeBodyDirectOnce = (
+  request: Record<string | symbol, any>
+): Promise<never> | undefined => {
+  if (request[bodyConsumedDirectlyKey]) {
+    return Promise.reject(throwBodyUnusable())
+  }
+  request[bodyConsumedDirectlyKey] = true
+  return undefined
+}
+
+const toArrayBuffer = (buf: Buffer): ArrayBuffer => {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
+}
+
+const contentType = (request: Record<string | symbol, any>): string => {
+  return (
+    (request[headersKey] ||= newHeadersFromIncoming(request[incomingKey])).get('content-type') || ''
+  )
+}
+
+type DirectBodyReadMethod = 'text' | 'arrayBuffer' | 'blob'
+
+const methodTokenRegExp = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+
+const normalizeIncomingMethod = (method: unknown): string => {
+  if (typeof method !== 'string' || method.length === 0) {
+    return 'GET'
+  }
+
+  // fast path for already-uppercase common methods from Node.js.
+  switch (method) {
+    case 'DELETE':
+    case 'GET':
+    case 'HEAD':
+    case 'OPTIONS':
+    case 'POST':
+    case 'PUT':
+      return method
+  }
+
+  const upper = method.toUpperCase()
+  switch (upper) {
+    case 'DELETE':
+    case 'GET':
+    case 'HEAD':
+    case 'OPTIONS':
+    case 'POST':
+    case 'PUT':
+      return upper
+    default:
+      return method
+  }
+}
+
+const validateDirectReadMethod = (method: string): TypeError | undefined => {
+  if (!methodTokenRegExp.test(method)) {
+    return new TypeError(`'${method}' is not a valid HTTP method.`)
+  }
+  // Keep TRACE workaround behavior, but preserve native rejection for other
+  // forbidden methods when using the direct-read fast path.
+  // Only exact upper-case TRACE is treated as the existing workaround target.
+  const normalized = method.toUpperCase()
+  if (
+    normalized === 'CONNECT' ||
+    normalized === 'TRACK' ||
+    (normalized === 'TRACE' && method !== 'TRACE')
+  ) {
+    return new TypeError(`'${method}' HTTP method is unsupported.`)
+  }
+  return undefined
+}
+
+const readBodyWithFastPath = <T>(
+  request: Record<string | symbol, any>,
+  method: DirectBodyReadMethod,
+  fromBuffer: (buf: Buffer, request: Record<string | symbol, any>) => T | Promise<T>
+): Promise<T> => {
+  if (request[bodyConsumedDirectlyKey]) {
+    return rejectBodyUnusable()
+  }
+
+  const methodName = request.method as string
+  if (methodName === 'GET' || methodName === 'HEAD') {
+    return request[getRequestCache]()[method]()
+  }
+
+  const methodValidationError = validateDirectReadMethod(methodName)
+  if (methodValidationError) {
+    return Promise.reject(methodValidationError)
+  }
+
+  if (request[requestCache]) {
+    // Keep TRACE direct-read behavior stable even if non-body properties
+    // created requestCache earlier (e.g. signal access).
+    if (methodName !== 'TRACE') {
+      const cachedRequest = request[requestCache] as Request
+      return cachedRequest[method]() as Promise<T>
+    }
+  }
+
+  const alreadyUsedError = consumeBodyDirectOnce(request)
+  if (alreadyUsedError) {
+    return alreadyUsedError
+  }
+
+  const raw = readRawBodyIfAvailable(request)
+  if (raw) {
+    const result = Promise.resolve(fromBuffer(raw, request))
+    request[bodyBufferKey] = undefined
+    return result
+  }
+
+  return readBodyDirect(request).then((buf) => {
+    const result = fromBuffer(buf, request)
+    request[bodyBufferKey] = undefined
+    return result
   })
+}
+
+const readRawBodyIfAvailable = (request: Record<string | symbol, any>): Buffer | undefined => {
+  const incoming = request[incomingKey] as IncomingMessage | Http2ServerRequest
+  if ('rawBody' in incoming && (incoming as any).rawBody instanceof Buffer) {
+    return (incoming as any).rawBody as Buffer
+  }
+  return undefined
+}
+
+// Read body directly from the IncomingMessage stream, bypassing Request object creation.
+// Precondition: the caller (listener.ts) must ensure that the IncomingMessage stream is
+// properly cleaned up (e.g. via incoming.resume()) when the response ends or the connection
+// closes. This function does not call incoming.destroy() on abort.
+const readBodyDirect = (request: Record<string | symbol, any>): Promise<Buffer> => {
+  if (request[bodyBufferKey]) {
+    return Promise.resolve(request[bodyBufferKey] as Buffer)
+  }
+  if (request[bodyReadPromiseKey]) {
+    return request[bodyReadPromiseKey] as Promise<Buffer>
+  }
+
+  const incoming = request[incomingKey] as IncomingMessage | Http2ServerRequest
+  if (Readable.isDisturbed(incoming)) {
+    return rejectBodyUnusable()
+  }
+
+  const promise = new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let settled = false
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      callback()
+    }
+
+    const onData = (chunk: Buffer | string) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+    const onEnd = () => {
+      finish(() => {
+        const buffer = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks)
+        request[bodyBufferKey] = buffer
+        resolve(buffer)
+      })
+    }
+    const onError = (error: unknown) => {
+      finish(() => {
+        reject(error)
+      })
+    }
+    const onClose = () => {
+      if (incoming.readableEnded) {
+        onEnd()
+        return
+      }
+      finish(() => {
+        if (incoming.errored) {
+          reject(incoming.errored)
+          return
+        }
+        const reason = request[abortReasonKey]
+        if (reason !== undefined) {
+          reject(reason instanceof Error ? reason : new Error(String(reason)))
+          return
+        }
+        reject(new Error('Client connection prematurely closed.'))
+      })
+    }
+    const cleanup = () => {
+      incoming.off('data', onData)
+      incoming.off('end', onEnd)
+      incoming.off('error', onError)
+      incoming.off('close', onClose)
+      request[bodyReadPromiseKey] = undefined
+    }
+
+    incoming.on('data', onData)
+    incoming.on('end', onEnd)
+    incoming.on('error', onError)
+    incoming.on('close', onClose)
+
+    // If the stream has already settled before listeners were attached,
+    // no further events will fire, so resolve/reject from the current state.
+    queueMicrotask(() => {
+      if (settled) {
+        return
+      }
+      if (incoming.readableEnded) {
+        onEnd()
+      } else if (incoming.errored) {
+        onError(incoming.errored)
+      } else if (incoming.destroyed) {
+        onClose()
+      }
+    })
+  })
+
+  request[bodyReadPromiseKey] = promise
+  return promise
 }
 
 const requestPrototype: Record<string | symbol, any> = {
   get method() {
-    return this[incomingKey].method || 'GET'
+    return normalizeIncomingMethod(this[incomingKey].method)
   },
 
   get url() {
@@ -139,46 +377,95 @@ const requestPrototype: Record<string | symbol, any> = {
     return (this[headersKey] ||= newHeadersFromIncoming(this[incomingKey]))
   },
 
+  [abortRequest](reason: unknown) {
+    if (this[abortReasonKey] === undefined) {
+      this[abortReasonKey] = reason
+    }
+    const abortController = this[abortControllerKey] as AbortController | undefined
+    if (abortController && !abortController.signal.aborted) {
+      abortController.abort(reason)
+    }
+  },
+
   [getAbortController]() {
-    this[getRequestCache]()
+    this[abortControllerKey] ||= new AbortController()
+    if (this[abortReasonKey] !== undefined && !this[abortControllerKey].signal.aborted) {
+      this[abortControllerKey].abort(this[abortReasonKey])
+    }
     return this[abortControllerKey]
   },
 
   [getRequestCache]() {
-    this[abortControllerKey] ||= new AbortController()
+    const abortController = this[getAbortController]()
     if (this[requestCache]) {
       return this[requestCache]
     }
-    // If body was already read directly, use cached buffer instead of re-reading stream
-    const incoming = this[incomingKey]
-    if (this[bodyBufferKey] && !(incoming.method === 'GET' || incoming.method === 'HEAD')) {
-      const buf = this[bodyBufferKey] as Buffer
+
+    const method = this.method
+
+    // If body was already consumed directly, create a minimal Request with an empty body
+    // to avoid holding the body buffer in memory via ReadableStream re-wrapping.
+    if (this[bodyConsumedDirectlyKey] && !(method === 'GET' || method === 'HEAD')) {
+      this[bodyBufferKey] = undefined
       const init = {
-        method: incoming.method,
+        method: method === 'TRACE' ? 'GET' : method,
         headers: this.headers,
-        signal: this[abortControllerKey].signal,
-        body: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array(buf))
-            controller.close()
-          },
-        }),
+        signal: abortController.signal,
       } as RequestInit
-      ;(init as any).duplex = 'half'
-      return (this[requestCache] = new Request(this[urlKey], init))
+      if (method !== 'TRACE') {
+        init.body = new ReadableStream({
+          start(c) {
+            c.close()
+          },
+        })
+        ;(init as any).duplex = 'half'
+      }
+      const req = new Request(this[urlKey], init)
+      if (method === 'TRACE') {
+        Object.defineProperty(req, 'method', {
+          get() {
+            return 'TRACE'
+          },
+        })
+      }
+      return (this[requestCache] = req)
     }
+
     return (this[requestCache] = newRequestFromIncoming(
       this.method,
       this[urlKey],
       this.headers,
       this[incomingKey],
-      this[abortControllerKey]
+      abortController
     ))
+  },
+
+  get body() {
+    if (!this[bodyConsumedDirectlyKey]) {
+      return this[getRequestCache]().body
+    }
+    const request = this[getRequestCache]()
+    if (!this[bodyLockReaderKey] && request.body) {
+      // Web standard requires body.locked === true when bodyUsed === true.
+      // After direct consumption (text/json/arrayBuffer/blob), getRequestCache() returns
+      // a Request with an empty ReadableStream body. We lock it here so that
+      // body.locked reflects the consumed state correctly.
+      this[bodyLockReaderKey] = request.body.getReader()
+    }
+    return request.body
+  },
+
+  get bodyUsed() {
+    if (this[bodyConsumedDirectlyKey]) {
+      return true
+    }
+    if (this[requestCache]) {
+      return this[requestCache].bodyUsed
+    }
+    return false
   },
 }
 ;[
-  'body',
-  'bodyUsed',
   'cache',
   'credentials',
   'destination',
@@ -199,65 +486,45 @@ const requestPrototype: Record<string | symbol, any> = {
 ;['clone', 'formData'].forEach((k) => {
   Object.defineProperty(requestPrototype, k, {
     value: function () {
+      if (this[bodyConsumedDirectlyKey]) {
+        if (k === 'clone') {
+          throwBodyUnusable()
+        }
+        return rejectBodyUnusable()
+      }
       return this[getRequestCache]()[k]()
     },
   })
 })
-// Direct body reading: bypass getRequestCache() → new AbortController() → newHeadersFromIncoming()
-// → new Request(url, init) → Readable.toWeb() chain. Read directly from Node.js IncomingMessage.
+// Direct body reading for text/arrayBuffer/blob/json: bypass getRequestCache()
+// → new AbortController() → newHeadersFromIncoming() → new Request(url, init)
+// → Readable.toWeb() chain for common body parsing cases.
 Object.defineProperty(requestPrototype, 'text', {
   value: function (): Promise<string> {
-    if (this[requestCache]) {
-      return this[requestCache].text()
-    }
-    const incoming = this[incomingKey] as IncomingMessage | Http2ServerRequest
-    if (incoming.method === 'GET' || incoming.method === 'HEAD') {
-      return Promise.resolve('')
-    }
-    if ('rawBody' in incoming && (incoming as any).rawBody instanceof Buffer) {
-      return Promise.resolve((incoming as any).rawBody.toString())
-    }
-    return readBodyDirect(incoming).then((buf) => {
-      this[bodyBufferKey] = buf
-      return buf.toString()
-    })
-  },
-})
-Object.defineProperty(requestPrototype, 'json', {
-  value: function (): Promise<any> {
-    if (this[requestCache]) {
-      return this[requestCache].json()
-    }
-    return this.text().then(JSON.parse)
+    return readBodyWithFastPath(this, 'text', (buf) => textDecoder.decode(buf))
   },
 })
 Object.defineProperty(requestPrototype, 'arrayBuffer', {
   value: function (): Promise<ArrayBuffer> {
-    if (this[requestCache]) {
-      return this[requestCache].arrayBuffer()
-    }
-    const incoming = this[incomingKey] as IncomingMessage | Http2ServerRequest
-    if (incoming.method === 'GET' || incoming.method === 'HEAD') {
-      return Promise.resolve(new ArrayBuffer(0))
-    }
-    if ('rawBody' in incoming && (incoming as any).rawBody instanceof Buffer) {
-      const raw = (incoming as any).rawBody as Buffer
-      return Promise.resolve(
-        raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength) as ArrayBuffer
-      )
-    }
-    return readBodyDirect(incoming).then((buf) => {
-      this[bodyBufferKey] = buf
-      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
-    })
+    return readBodyWithFastPath(this, 'arrayBuffer', (buf) => toArrayBuffer(buf))
   },
 })
 Object.defineProperty(requestPrototype, 'blob', {
   value: function (): Promise<Blob> {
-    if (this[requestCache]) {
-      return this[requestCache].blob()
+    return readBodyWithFastPath(this, 'blob', (buf, request) => {
+      const type = contentType(request)
+      const init = type ? { headers: { 'content-type': type } } : undefined
+      return new Response(buf, init).blob()
+    })
+  },
+})
+// json() reuses text() fast path to keep body consumption logic centralized.
+Object.defineProperty(requestPrototype, 'json', {
+  value: function (): Promise<any> {
+    if (this[bodyConsumedDirectlyKey]) {
+      return rejectBodyUnusable()
     }
-    return this.arrayBuffer().then((buf: ArrayBuffer) => new Blob([buf]))
+    return this.text().then(JSON.parse)
   },
 })
 Object.setPrototypeOf(requestPrototype, Request.prototype)

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -4,6 +4,7 @@ import { Http2ServerRequest } from 'node:http2'
 import { Socket } from 'node:net'
 import { Duplex } from 'node:stream'
 import {
+  abortRequest,
   newRequest,
   Request as LightweightRequest,
   GlobalRequest,
@@ -119,6 +120,559 @@ describe('Request', () => {
 
       expect(req[getAbortController]()).toBeDefined()
       expect(req[abortControllerKey]).toBeDefined() // initialized
+    })
+
+    it('should apply abort state lazily when signal is accessed after json() body read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      expect(await req.json()).toEqual({ foo: 'bar' })
+      expect(req[abortControllerKey]).toBeUndefined()
+
+      req[abortRequest]('Client connection prematurely closed.')
+      expect(req[abortControllerKey]).toBeUndefined()
+
+      expect(req.signal.aborted).toBe(true)
+    })
+
+    it('should reject direct body read when incoming stream is destroyed mid-read', async () => {
+      const socket = new Socket()
+      const incomingMessage = new IncomingMessage(socket)
+      incomingMessage.method = 'POST'
+      incomingMessage.headers = {
+        host: 'localhost',
+      }
+      incomingMessage.rawHeaders = ['host', 'localhost']
+      incomingMessage.url = '/foo.txt'
+      const req = newRequest(incomingMessage)
+
+      const textPromise = req.json()
+      incomingMessage.destroy(new Error('Client connection prematurely closed.'))
+
+      await expect(textPromise).rejects.toBeInstanceOf(Error)
+    })
+
+    it('should reject direct body read when incoming stream is destroyed without error', async () => {
+      const socket = new Socket()
+      const incomingMessage = new IncomingMessage(socket)
+      incomingMessage.method = 'POST'
+      incomingMessage.headers = {
+        host: 'localhost',
+      }
+      incomingMessage.rawHeaders = ['host', 'localhost']
+      incomingMessage.url = '/foo.txt'
+      const req = newRequest(incomingMessage)
+
+      const textPromise = req.text()
+      incomingMessage.destroy()
+
+      await expect(textPromise).rejects.toBeInstanceOf(Error)
+    })
+
+    it('should reject direct body read for unsupported methods like native Request', async () => {
+      for (const method of ['CONNECT', 'TRACK']) {
+        const req = newRequest({
+          method,
+          headers: {
+            host: 'localhost',
+            'content-type': 'text/plain',
+          },
+          rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+          rawBody: Buffer.from('foo'),
+          url: '/foo.txt',
+        } as IncomingMessage & { rawBody: Buffer })
+
+        await expect(req.text()).rejects.toBeInstanceOf(TypeError)
+      }
+    })
+
+    it('should allow direct body read even when aborted before rawBody read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      req[abortRequest]('Client connection prematurely closed.')
+
+      await expect(req.json()).resolves.toEqual({ foo: 'bar' })
+    })
+
+    it('should allow json() read even after signal is accessed first and then aborted', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      req[abortRequest]('Client connection prematurely closed.')
+      expect(req.signal.aborted).toBe(true)
+
+      await expect(req.json()).resolves.toEqual({ foo: 'bar' })
+    })
+
+    it('should keep bodyUsed consistent after aborted read regardless of signal access order', async () => {
+      const reqWithoutSignal = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      reqWithoutSignal[abortRequest]('Client connection prematurely closed.')
+      await expect(reqWithoutSignal.json()).resolves.toEqual({ foo: 'bar' })
+      expect(reqWithoutSignal.bodyUsed).toBe(true)
+
+      const reqWithSignal = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      expect(reqWithSignal.signal.aborted).toBe(false)
+      reqWithSignal[abortRequest]('Client connection prematurely closed.')
+      expect(reqWithSignal.signal.aborted).toBe(true)
+      await expect(reqWithSignal.json()).resolves.toEqual({ foo: 'bar' })
+      expect(reqWithSignal.bodyUsed).toBe(true)
+    })
+
+    it('should allow clone() and formData() after abort like native Request', async () => {
+      const reqForClone = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      reqForClone[abortRequest]('Client connection prematurely closed.')
+      const cloned = reqForClone.clone()
+      await expect(cloned.text()).resolves.toBe('foo')
+
+      const reqForFormData = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/x-www-form-urlencoded'],
+        rawBody: Buffer.from('a=1&b=2'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      reqForFormData[abortRequest]('Client connection prematurely closed.')
+      const formData = await reqForFormData.formData()
+      expect(formData.get('a')).toBe('1')
+      expect(formData.get('b')).toBe('2')
+    })
+
+    it('should reject direct body read when incoming stream has already been consumed', async () => {
+      const socket = new Socket()
+      const incomingMessage = new IncomingMessage(socket)
+      incomingMessage.method = 'POST'
+      incomingMessage.headers = {
+        host: 'localhost',
+      }
+      incomingMessage.rawHeaders = ['host', 'localhost']
+      incomingMessage.url = '/foo.txt'
+      incomingMessage.push('foo')
+      incomingMessage.push(null)
+
+      for await (const chunk of incomingMessage) {
+        // consume body before lightweight request reads it
+        expect(chunk).toBeDefined()
+      }
+
+      const req = newRequest(incomingMessage)
+      await expect(req.text()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should resolve direct body read when stream already ended before first read', async () => {
+      const socket = new Socket()
+      const incomingMessage = new IncomingMessage(socket)
+      incomingMessage.method = 'POST'
+      incomingMessage.headers = {
+        host: 'localhost',
+      }
+      incomingMessage.rawHeaders = ['host', 'localhost']
+      incomingMessage.url = '/foo.txt'
+
+      const req = newRequest(incomingMessage)
+      const ended = new Promise<void>((resolve) => {
+        incomingMessage.once('end', () => {
+          resolve()
+        })
+      })
+      incomingMessage.push(null)
+      incomingMessage.resume()
+      await ended
+
+      await expect(req.text()).resolves.toBe('')
+      expect(req.bodyUsed).toBe(true)
+    })
+
+    it('should reject on second direct json() read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await expect(req.json()).resolves.toEqual({ foo: 'bar' })
+      await expect(req.json()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should set bodyUsed and reject clone() after direct json() read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await expect(req.json()).resolves.toEqual({ foo: 'bar' })
+      expect(req.bodyUsed).toBe(true)
+      expect(() => req.clone()).toThrow(TypeError)
+      await expect(req.text()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should support UTF-8 BOM in direct json() read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from('{"foo":"bar"}')]),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await expect(req.json()).resolves.toEqual({ foo: 'bar' })
+    })
+
+    it('should set bodyUsed and reject clone() after direct text() read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await expect(req.text()).resolves.toBe('foo')
+      expect(req.bodyUsed).toBe(true)
+      expect(() => req.clone()).toThrow(TypeError)
+      await expect(req.arrayBuffer()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should reject second direct text() read even after accessing signal', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await expect(req.text()).resolves.toBe('foo')
+      expect(req.signal.aborted).toBe(false)
+      await expect(req.text()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should reject second direct json() read even after accessing signal', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/json',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/json'],
+        rawBody: Buffer.from('{"foo":"bar"}'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await expect(req.json()).resolves.toEqual({ foo: 'bar' })
+      expect(req.signal.aborted).toBe(false)
+      await expect(req.json()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should set bodyUsed and reject clone() after direct arrayBuffer() read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'application/octet-stream',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'application/octet-stream'],
+        rawBody: Buffer.from([1, 2, 3]),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      const ab = await req.arrayBuffer()
+      expect(new Uint8Array(ab)).toEqual(new Uint8Array([1, 2, 3]))
+      expect(req.bodyUsed).toBe(true)
+      expect(() => req.clone()).toThrow(TypeError)
+      await expect(req.text()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should preserve content type in blob() result', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await expect(req.blob().then((blob: Blob) => blob.type)).resolves.toBe('text/plain')
+    })
+
+    it('should normalize content type in blob() result like native Request', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain; charset=UTF-8',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain; charset=UTF-8'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      const expectedType = await new GlobalRequest('http://localhost/foo.txt', {
+        method: 'POST',
+        headers: {
+          'content-type': 'text/plain; charset=UTF-8',
+        },
+        body: 'foo',
+      })
+        .blob()
+        .then((blob: Blob) => blob.type)
+
+      await expect(req.blob().then((blob: Blob) => blob.type)).resolves.toBe(expectedType)
+    })
+
+    it('should set bodyUsed and reject clone() after direct blob() read', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      const blob = await req.blob()
+      expect(blob.type).toBe('text/plain')
+      expect(await blob.text()).toBe('foo')
+      expect(req.bodyUsed).toBe(true)
+      expect(() => req.clone()).toThrow(TypeError)
+      await expect(req.json()).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('should allow constructing Request from consumed lightweight request when body is replaced', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await req.text()
+
+      const req2 = new LightweightRequest(req, {
+        method: 'POST',
+        body: 'bar',
+      })
+      await expect(req2.text()).resolves.toBe('bar')
+    })
+
+    it('should throw when constructing Request from consumed lightweight request without body replacement', async () => {
+      const req = newRequest({
+        method: 'POST',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      await req.text()
+
+      expect(() => {
+        new LightweightRequest(req)
+      }).toThrow(TypeError)
+    })
+
+    it('should preserve TRACE workaround after direct read when accessing signal', async () => {
+      const socket = new Socket()
+      const incomingMessage = new IncomingMessage(socket)
+      incomingMessage.method = 'TRACE'
+      incomingMessage.headers = {
+        host: 'localhost',
+        'content-type': 'text/plain',
+      }
+      incomingMessage.rawHeaders = ['host', 'localhost', 'content-type', 'text/plain']
+      incomingMessage.url = '/foo.txt'
+      ;(incomingMessage as IncomingMessage & { rawBody: Buffer }).rawBody = Buffer.from('foo')
+      const req = newRequest(incomingMessage)
+
+      await expect(req.text()).resolves.toBe('foo')
+      expect(() => req.signal).not.toThrow()
+    })
+
+    it('should keep TRACE direct body read behavior regardless of signal access order', async () => {
+      const createTraceRequest = () => {
+        const socket = new Socket()
+        const incomingMessage = new IncomingMessage(socket)
+        incomingMessage.method = 'TRACE'
+        incomingMessage.headers = {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        }
+        incomingMessage.rawHeaders = ['host', 'localhost', 'content-type', 'text/plain']
+        incomingMessage.url = '/foo.txt'
+        ;(incomingMessage as IncomingMessage & { rawBody: Buffer }).rawBody = Buffer.from('foo')
+        return newRequest(incomingMessage)
+      }
+
+      const reqBeforeSignal = createTraceRequest()
+      await expect(reqBeforeSignal.text()).resolves.toBe('foo')
+
+      const reqAfterSignal = createTraceRequest()
+      expect(() => reqAfterSignal.signal).not.toThrow()
+      await expect(reqAfterSignal.text()).resolves.toBe('foo')
+    })
+
+    it('should reject non-uppercase trace consistently regardless of access order', async () => {
+      const createTraceLikeRequest = (method: string) => {
+        const socket = new Socket()
+        const incomingMessage = new IncomingMessage(socket)
+        incomingMessage.method = method
+        incomingMessage.headers = {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        }
+        incomingMessage.rawHeaders = ['host', 'localhost', 'content-type', 'text/plain']
+        incomingMessage.url = '/foo.txt'
+        ;(incomingMessage as IncomingMessage & { rawBody: Buffer }).rawBody = Buffer.from('foo')
+        return newRequest(incomingMessage)
+      }
+
+      for (const method of ['trace', 'TrAcE']) {
+        const reqBeforeSignal = createTraceLikeRequest(method)
+        await expect(reqBeforeSignal.text()).rejects.toBeInstanceOf(TypeError)
+
+        const reqAfterSignal = createTraceLikeRequest(method)
+        expect(() => reqAfterSignal.signal).toThrow(/HTTP method is unsupported/)
+      }
+    })
+
+    it('should preserve non-standard method casing like native Request', async () => {
+      for (const method of ['patch', 'CuStOm']) {
+        const req = newRequest({
+          method,
+          headers: {
+            host: 'localhost',
+          },
+          rawHeaders: ['host', 'localhost'],
+          url: '/foo.txt',
+        } as IncomingMessage)
+
+        const expected = new GlobalRequest('http://localhost/foo.txt', { method }).method
+        expect(req.method).toBe(expected)
+      }
+    })
+
+    it('should normalize lowercase methods and keep GET behavior consistent', async () => {
+      const req = newRequest({
+        method: 'get',
+        headers: {
+          host: 'localhost',
+          'content-type': 'text/plain',
+        },
+        rawHeaders: ['host', 'localhost', 'content-type', 'text/plain'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      expect(req.method).toBe('GET')
+      expect(() => req.signal).not.toThrow()
+      await expect(req.text()).resolves.toBe('')
+      expect(req.bodyUsed).toBe(false)
+    })
+
+    it('should keep default GET behavior when incoming.method is missing', async () => {
+      const req = newRequest({
+        headers: {
+          host: 'localhost',
+        },
+        rawHeaders: ['host', 'localhost'],
+        rawBody: Buffer.from('foo'),
+        url: '/foo.txt',
+      } as IncomingMessage & { rawBody: Buffer })
+
+      expect(req.method).toBe('GET')
+      expect(await req.text()).toBe('')
+      expect(req.bodyUsed).toBe(false)
+      expect(() => req.signal).not.toThrow()
     })
 
     it('Should throw error if host header contains path', async () => {


### PR DESCRIPTION
This PR applies fixes to maintain compatibility with web standards for the request body optimization merged in #301.

It seems we can implement this without significantly reducing the performance gains, but it will likely require a considerable amount of code. Maintenance costs also look substantial.


```
============================================================
BENCHMARK RESULTS
============================================================

| Benchmark         | npm            | dev            | Difference  |
| ----------------- | -------------- | -------------- | ----------- |
| Average           | 50,527.59      | 61,093.99      | +20.91%     |
| Ping (GET /)      | 65,812.06      | 70,197.87      | +6.66%      |
| Query (GET /id)   | 64,671.18      | 69,099.75      | +6.85%      |
| Body (POST /json) | 21,099.52      | 43,984.34      | +108.46%    |
```