### PR TITLE
fix: add custom inspect to lightweight Request/Response to prevent TypeError on console.log

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -180,6 +180,20 @@ const requestPrototype: Record<string | symbol, any> = {
     },
   })
 })
+
+Object.defineProperty(requestPrototype, Symbol.for('nodejs.util.inspect.custom'), {
+  value: function (depth: number, options: object, inspectFn: Function) {
+    const props: Record<string, unknown> = {
+      method: this.method,
+      url: this.url,
+      headers: this.headers,
+      nativeRequest: this[requestCache],
+    }
+
+    return `Request (lightweight) ${inspectFn(props, { ...options, depth: depth == null ? null : depth - 1 })}`
+  },
+})
+
 Object.setPrototypeOf(requestPrototype, Request.prototype)
 
 export const newRequest = (

--- a/src/response.ts
+++ b/src/response.ts
@@ -95,5 +95,18 @@ export class Response {
     },
   })
 })
+
+Object.defineProperty(Response.prototype, Symbol.for('nodejs.util.inspect.custom'), {
+  value: function (depth: number, options: object, inspectFn: Function) {
+    const props: Record<string, unknown> = {
+      status: this.status,
+      headers: this.headers,
+      ok: this.ok,
+      nativeResponse: (this as LightResponse)[responseCache],
+    }
+    return `Response (lightweight) ${inspectFn(props, { ...options, depth: depth == null ? null : depth - 1 })}`
+  },
+})
+
 Object.setPrototypeOf(Response, GlobalResponse)
 Object.setPrototypeOf(Response.prototype, GlobalResponse.prototype)

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -342,6 +342,49 @@ describe('Request', () => {
   })
 })
 
+describe('util.inspect', () => {
+  it('should show a lightweight request summary without creating a native Request', () => {
+    const { inspect } = require('node:util')
+    const req = newRequest({
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost',
+      },
+      rawHeaders: ['host', 'localhost'],
+    } as IncomingMessage)
+
+    expect(() => inspect(req)).not.toThrow()
+    const result = inspect(req)
+    expect(result).toContain('Request (lightweight)')
+    expect(result).toContain('GET')
+    expect(result).toContain('http://localhost/')
+    expect(result).toContain('nativeRequest: undefined')
+    expect(req[abortControllerKey]).toBeUndefined()
+    expect(req).toBeInstanceOf(global.Request)
+  })
+
+  it('should include the native Request after cache creation', () => {
+    const { inspect } = require('node:util')
+    const req = newRequest({
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost',
+      },
+      rawHeaders: ['host', 'localhost'],
+    } as IncomingMessage)
+
+    // Access keepalive to trigger native Request creation via getRequestCache()
+    req.keepalive
+
+    const result = inspect(req)
+    expect(result).toContain('Request (lightweight)')
+    expect(result).toContain('nativeRequest: Request {')
+    expect(req[abortControllerKey]).toBeDefined()
+  })
+})
+
 describe('RequestError', () => {
   it('should have a static name property (class name)', () => {
     expect(RequestError.name).toBe('RequestError')

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -118,4 +118,30 @@ describe('Response', () => {
       expect(cacheKey in res).toBe(false)
     })
   })
+
+  describe('util.inspect', () => {
+    it('should show a lightweight response summary before native Response creation', () => {
+      const { inspect } = require('node:util')
+      const res = new Response('Hello')
+
+      expect(() => inspect(res)).not.toThrow()
+      const result = inspect(res)
+      expect(result).toContain('Response (lightweight)')
+      expect(result).toContain('200')
+      expect(result).toContain('nativeResponse: undefined')
+      expect(res).toBeInstanceOf(GlobalResponse)
+    })
+
+    it('should include the native Response after cache creation', async () => {
+      const { inspect } = require('node:util')
+      const res = new Response('Hello', { statusText: 'OK' })
+
+      // Access statusText to trigger native Response creation
+      res.statusText
+
+      const result = inspect(res)
+      expect(result).toContain('Response (lightweight)')
+      expect(result).toContain('nativeResponse: Response {')
+    })
+  })
 })


### PR DESCRIPTION
fixes #339

### example output

#### before creating internal cache

```
Request (lightweight) {
  method: 'GET',
  url: 'http://localhost/',
  headers: Headers { host: 'localhost' },
  nativeRequest: undefined
}
```

#### after creating internal cache

```
Request (lightweight) {
  method: 'GET',
  url: 'http://localhost/',
  headers: Headers { host: 'localhost' },
  nativeRequest: Request {
    method: 'GET',
    url: 'http://localhost/',
    headers: Headers { host: 'localhost' },
    destination: '',
    referrer: 'about:client',
    referrerPolicy: '',
    mode: 'cors',
    credentials: 'same-origin',
    cache: 'default',
    redirect: 'follow',
    integrity: '',
    keepalive: false,
    isReloadNavigation: false,
    isHistoryNavigation: false,
    signal: AbortSignal { aborted: false }
  }
}
```

#### before creating internal cache

```
Response (lightweight) {
  status: 200,
  headers: Headers { 'content-type': 'text/plain; charset=UTF-8' },
  ok: true,
  nativeResponse: undefined
}
```

#### after creating internal cache

```
Response (lightweight) {
  status: 200,
  headers: Headers { 'content-type': 'text/plain;charset=UTF-8' },
  ok: true,
  nativeResponse: Response {
    status: 200,
    statusText: 'OK',
    headers: Headers { 'content-type': 'text/plain;charset=UTF-8' },
    body: ReadableStream { locked: false, state: 'readable', supportsBYOB: true },
    bodyUsed: false,
    ok: true,
    redirected: false,
    type: 'default',
    url: ''
  }
}
```