### PR TITLE
refactor: improve handling of null body in response

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -157,8 +157,8 @@ const responseViaCache = async (
   // Fast path: no custom headers — create the final header object in one shot
   // (avoids shape transitions from mutating a single-key object).
   if (!header) {
-    if (body == null) {
-      outgoing.writeHead(status, {})
+    if (body === null) {
+      outgoing.writeHead(status)
       outgoing.end()
     } else if (typeof body === 'string') {
       outgoing.writeHead(status, {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -10,7 +10,7 @@ import {
   wrapBodyStream,
   toRequestError,
 } from './request'
-import { cacheKey, Response as LightweightResponse } from './response'
+import { defaultContentType, cacheKey, Response as LightweightResponse } from './response'
 import type { InternalCache } from './response'
 import type { CustomErrorHandler, FetchCallback, HttpBindings } from './types'
 import {
@@ -162,24 +162,24 @@ const responseViaCache = async (
       outgoing.end()
     } else if (typeof body === 'string') {
       outgoing.writeHead(status, {
-        'content-type': 'text/plain; charset=UTF-8',
+        'Content-Type': defaultContentType,
         'Content-Length': Buffer.byteLength(body),
       })
       outgoing.end(body)
     } else if (body instanceof Uint8Array) {
       outgoing.writeHead(status, {
-        'content-type': 'text/plain; charset=UTF-8',
+        'Content-Type': defaultContentType,
         'Content-Length': body.byteLength,
       })
       outgoing.end(body)
     } else if (body instanceof Blob) {
       outgoing.writeHead(status, {
-        'content-type': 'text/plain; charset=UTF-8',
+        'Content-Type': defaultContentType,
         'Content-Length': body.size,
       })
       outgoing.end(new Uint8Array(await body.arrayBuffer()))
     } else {
-      outgoing.writeHead(status, { 'content-type': 'text/plain; charset=UTF-8' })
+      outgoing.writeHead(status, { 'Content-Type': defaultContentType })
       flushHeaders(outgoing)
       await writeFromReadableStream(body, outgoing)?.catch(
         (e) => handleResponseError(e, outgoing) as undefined
@@ -192,11 +192,11 @@ const responseViaCache = async (
   let hasContentLength = false
   if (header instanceof Headers) {
     hasContentLength = header.has('content-length')
-    header = buildOutgoingHttpHeaders(header)
+    header = buildOutgoingHttpHeaders(header, body === null ? undefined : defaultContentType)
   } else if (Array.isArray(header)) {
     const headerObj = new Headers(header)
     hasContentLength = headerObj.has('content-length')
-    header = buildOutgoingHttpHeaders(headerObj)
+    header = buildOutgoingHttpHeaders(headerObj, body === null ? undefined : defaultContentType)
   } else {
     for (const key in header) {
       if (key.length === 14 && key.toLowerCase() === 'content-length') {
@@ -262,7 +262,10 @@ const responseViaResponseObject = async (
     return responseViaCache(res as Response, outgoing)
   }
 
-  const resHeaderRecord: OutgoingHttpHeaders = buildOutgoingHttpHeaders(res.headers)
+  const resHeaderRecord: OutgoingHttpHeaders = buildOutgoingHttpHeaders(
+    res.headers,
+    res.body === null ? undefined : defaultContentType
+  )
 
   if (res.body) {
     const reader = res.body.getReader()

--- a/src/response.ts
+++ b/src/response.ts
@@ -3,6 +3,8 @@
 
 import type { OutgoingHttpHeaders } from 'node:http'
 
+export const defaultContentType = 'text/plain; charset=UTF-8'
+
 const responseCache = Symbol('responseCache')
 const getResponseCache = Symbol('getResponseCache')
 export const cacheKey = Symbol('cache')
@@ -63,7 +65,10 @@ export class Response {
     if (cache) {
       if (!(cache[2] instanceof Headers)) {
         cache[2] = new Headers(
-          (cache[2] || { 'content-type': 'text/plain; charset=UTF-8' }) as HeadersInit
+          (cache[2] ||
+            (cache[1] === null
+              ? undefined
+              : { 'content-type': defaultContentType })) as HeadersInit
         )
       }
       return cache[2]

--- a/src/response.ts
+++ b/src/response.ts
@@ -49,8 +49,7 @@ export class Response {
     }
 
     if (
-      body === null ||
-      body === undefined ||
+      body == null ||
       typeof body === 'string' ||
       typeof (body as ReadableStream)?.getReader !== 'undefined' ||
       body instanceof Blob ||

--- a/src/response.ts
+++ b/src/response.ts
@@ -65,9 +65,7 @@ export class Response {
       if (!(cache[2] instanceof Headers)) {
         cache[2] = new Headers(
           (cache[2] ||
-            (cache[1] === null
-              ? undefined
-              : { 'content-type': defaultContentType })) as HeadersInit
+            (cache[1] === null ? undefined : { 'content-type': defaultContentType })) as HeadersInit
         )
       }
       return cache[2]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,7 +87,7 @@ export const buildOutgoingHttpHeaders = (
       res[k] = v
     }
   }
-  
+
   if (defaultContentType) {
     res['content-type'] ??= defaultContentType
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,8 @@ export function writeFromReadableStream(stream: ReadableStream<Uint8Array>, writ
 }
 
 export const buildOutgoingHttpHeaders = (
-  headers: Headers | HeadersInit | null | undefined
+  headers: Headers | HeadersInit | null | undefined,
+  defaultContentType: string | undefined
 ): OutgoingHttpHeaders => {
   const res: OutgoingHttpHeaders = {}
   if (!(headers instanceof Headers)) {
@@ -86,7 +87,10 @@ export const buildOutgoingHttpHeaders = (
       res[k] = v
     }
   }
-  res['content-type'] ??= 'text/plain; charset=UTF-8'
+  
+  if (defaultContentType) {
+    res['content-type'] ??= defaultContentType
+  }
 
   return res
 }

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -81,6 +81,20 @@ describe('Invalid request', () => {
   })
 })
 
+describe('Response headers', () => {
+  const requestListener = getRequestListener(() => new Response(null), {
+    hostname: 'example.com',
+  })
+  const server = createServer(requestListener)
+
+  it('Should not set content-type for a null body response', async () => {
+    const res = await request(server).get('/').send()
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toBeUndefined()
+    expect(res.text).toBe('')
+  })
+})
+
 describe('Error handling - sync fetchCallback', () => {
   const fetchCallback = vi.fn(() => {
     throw new Error('thrown error')

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -11,41 +11,41 @@ describe('buildOutgoingHttpHeaders', () => {
       a: 'b',
       'content-type': 'text/html; charset=UTF-8',
     })
-    const result = buildOutgoingHttpHeaders(headers)
+    const result = buildOutgoingHttpHeaders(headers, 'text/plain; charset=UTF-8')
     expect(result).toEqual({
       a: 'b',
       'content-type': 'text/html; charset=UTF-8',
     })
   })
 
-  it('multiple set-cookie', () => {
+  it('multiple set-cookie with default content-type', () => {
     const headers = new Headers()
     headers.append('set-cookie', 'a')
     headers.append('set-cookie', 'b')
-    const result = buildOutgoingHttpHeaders(headers)
+    const result = buildOutgoingHttpHeaders(headers, 'text/plain; charset=UTF-8')
     expect(result).toEqual({
       'set-cookie': ['a', 'b'],
       'content-type': 'text/plain; charset=UTF-8',
     })
   })
 
-  it('Headers', () => {
+  it('Headers with default content-type', () => {
     const headers = new Headers({
       a: 'b',
     })
-    const result = buildOutgoingHttpHeaders(headers)
+    const result = buildOutgoingHttpHeaders(headers, 'text/plain; charset=UTF-8')
     expect(result).toEqual({
       a: 'b',
       'content-type': 'text/plain; charset=UTF-8',
     })
   })
 
-  it('Record<string, string>', () => {
+  it('Record<string, string> with default content-type', () => {
     const headers = {
       a: 'b',
       'Set-Cookie': 'c', // case-insensitive
     }
-    const result = buildOutgoingHttpHeaders(headers)
+    const result = buildOutgoingHttpHeaders(headers, 'text/plain; charset=UTF-8')
     expect(result).toEqual({
       a: 'b',
       'set-cookie': ['c'],
@@ -53,26 +53,41 @@ describe('buildOutgoingHttpHeaders', () => {
     })
   })
 
-  it('Record<string, string>[]', () => {
+  it('Record<string, string>[] with default content-type', () => {
     const headers: HeadersInit = [['a', 'b']]
-    const result = buildOutgoingHttpHeaders(headers)
+    const result = buildOutgoingHttpHeaders(headers, 'text/plain; charset=UTF-8')
     expect(result).toEqual({
       a: 'b',
       'content-type': 'text/plain; charset=UTF-8',
     })
   })
 
-  it('null', () => {
-    const result = buildOutgoingHttpHeaders(null)
+  it('null without default content-type', () => {
+    const result = buildOutgoingHttpHeaders(null, undefined)
+    expect(result).toEqual({})
+  })
+
+  it('undefined without default content-type', () => {
+    const result = buildOutgoingHttpHeaders(undefined, undefined)
+    expect(result).toEqual({})
+  })
+
+  it('null with default content-type', () => {
+    const result = buildOutgoingHttpHeaders(null, 'text/plain; charset=UTF-8')
     expect(result).toEqual({
       'content-type': 'text/plain; charset=UTF-8',
     })
   })
 
-  it('undefined', () => {
-    const result = buildOutgoingHttpHeaders(undefined)
+  it('does not override existing content-type when default is provided', () => {
+    const result = buildOutgoingHttpHeaders(
+      {
+        'content-type': 'application/json',
+      },
+      'text/plain; charset=UTF-8'
+    )
     expect(result).toEqual({
-      'content-type': 'text/plain; charset=UTF-8',
+      'content-type': 'application/json',
     })
   })
 })


### PR DESCRIPTION
This PR includes a minor bug fix and refactoring related to `new Response(null)`, which was improved in #333.

## Summary

* fix: Fix an issue where `Content-Type` header was unnecessarily set on responses with a `null` body (e.g., `new Response(null)`)
    * https://github.com/honojs/node-server/pull/341/changes#diff-0a9945c399ef4b66209b330f33399ac079477f017039f62d33e7d8296163469dL160-R161
* fix: Per the Fetch spec, responses with a null body should not include a `Content-Type` header
    * https://github.com/honojs/node-server/pull/341/changes#diff-0a9945c399ef4b66209b330f33399ac079477f017039f62d33e7d8296163469dL265-R268
    * https://github.com/honojs/node-server/pull/341/changes#diff-8c103f2199265c6a0659504dac715a5bc176ab1f494fc64fb06a5f4a814094c0L66-R68
* refactor: Define `defaultContentType` as a constant and pass it explicitly to `buildOutgoingHttpHeaders`
    * https://github.com/honojs/node-server/pull/341/changes#diff-8c103f2199265c6a0659504dac715a5bc176ab1f494fc64fb06a5f4a814094c0R6