### PR TITLE
fix: forward Hono response headers during WebSocket upgrade

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -57,11 +57,45 @@ type UpgradeWebSocketOptions = {
   onError: (err: unknown) => void
 }
 
-const rejectUpgradeRequest = (socket: Duplex, status: number) => {
+// Hop-by-hop headers per RFC 9110 Section 7.6.1
+// (https://www.rfc-editor.org/rfc/rfc9110.html#name-connection) plus
+// `keep-alive` (commonly treated as hop-by-hop by HTTP implementations) and
+// WebSocket handshake headers managed by `ws` itself. These must not be
+// forwarded onto the upgrade response or the handshake will be corrupted.
+const responseHeadersToSkip = new Set([
+  'connection',
+  'content-length',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'sec-websocket-accept',
+  'sec-websocket-extensions',
+  'sec-websocket-protocol',
+])
+
+const appendResponseHeaders = (headers: string[], responseHeaders?: Headers) => {
+  if (!responseHeaders) {
+    return
+  }
+  responseHeaders.forEach((value, key) => {
+    if (responseHeadersToSkip.has(key.toLowerCase())) {
+      return
+    }
+    headers.push(`${key}: ${value}`)
+  })
+}
+
+const rejectUpgradeRequest = (socket: Duplex, status: number, responseHeaders?: Headers) => {
+  const responseLines = ['Connection: close', 'Content-Length: 0']
+  appendResponseHeaders(responseLines, responseHeaders)
+
   socket.end(
     `HTTP/1.1 ${status.toString()} ${STATUS_CODES[status] ?? ''}\r\n` +
-      'Connection: close\r\n' +
-      'Content-Length: 0\r\n' +
+      `${responseLines.join('\r\n')}\r\n` +
       '\r\n'
   )
 }
@@ -121,6 +155,7 @@ export const setupWebSocket = (options: {
     }
 
     let status = 400
+    let responseHeaders: Headers | undefined
     try {
       const response = (await fetchCallback(
         createUpgradeRequest(request),
@@ -128,6 +163,7 @@ export const setupWebSocket = (options: {
       )) as Response
       if (response instanceof Response) {
         status = response.status
+        responseHeaders = response.headers
       }
     } catch {
       if (server.listenerCount('upgrade') === 1) {
@@ -141,14 +177,25 @@ export const setupWebSocket = (options: {
     if (!waiter || waiter.connectionSymbol !== env[CONNECTION_SYMBOL_KEY]) {
       waiterMap.delete(request)
       if (server.listenerCount('upgrade') === 1) {
-        rejectUpgradeRequest(socket, status)
+        rejectUpgradeRequest(socket, status, responseHeaders)
       }
       return
     }
 
-    wss.handleUpgrade(request, socket, head, (ws) => {
-      wss.emit('connection', ws, request)
-    })
+    const addResponseHeaders = (headers: string[]) => {
+      appendResponseHeaders(headers, responseHeaders)
+    }
+
+    // `headers` is emitted synchronously inside `handleUpgrade`, so this
+    // listener cannot leak across concurrent upgrades on the shared `wss`.
+    wss.on('headers', addResponseHeaders)
+    try {
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        wss.emit('connection', ws, request)
+      })
+    } finally {
+      wss.off('headers', addResponseHeaders)
+    }
   })
 
   server.on('close', () => {

--- a/test/websocket.test.ts
+++ b/test/websocket.test.ts
@@ -69,6 +69,73 @@ describe('WebSocket', () => {
     }
   })
 
+  it('should forward response headers set by middleware on a successful upgrade', async () => {
+    const app = new Hono()
+
+    app.use(async (c, next) => {
+      await next()
+      c.header('x-auth-result', c.req.header('authorization') ? 'authorized' : 'missing')
+    })
+    app.get(
+      '/ws',
+      upgradeWebSocket(() => ({}))
+    )
+
+    const { server, address } = await startServer(app)
+
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${address.port}/ws`, {
+        headers: {
+          authorization: 'Bearer token',
+        },
+      })
+      const responseHeaders = await new Promise<Record<string, string | string[] | undefined>>(
+        (resolve, reject) => {
+          ws.once('upgrade', (response) => {
+            resolve(response.headers)
+          })
+          ws.once('error', reject)
+        }
+      )
+      expect(responseHeaders['x-auth-result']).toBe('authorized')
+      ws.close()
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('should forward response headers when the upgrade is rejected', async () => {
+    const app = new Hono()
+
+    app.get(
+      '/ws',
+      () =>
+        new Response(null, {
+          status: 401,
+          headers: {
+            'x-auth-result': 'missing',
+          },
+        })
+    )
+
+    const { server, address } = await startServer(app)
+
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${address.port}/ws`)
+      const responseHeaders = await new Promise<Record<string, string | string[] | undefined>>(
+        (resolve, reject) => {
+          ws.once('unexpected-response', (_, response) => {
+            resolve(response.headers)
+          })
+          ws.once('open', () => reject(new Error('WebSocket must not be upgraded')))
+        }
+      )
+      expect(responseHeaders['x-auth-result']).toBe('missing')
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
   it('should not block other upgrade listeners', async () => {
     const app = new Hono()
     const { server, address } = await startServer(app)


### PR DESCRIPTION
## Summary

Forward headers attached to the `Response` returned by the Hono app to the WebSocket upgrade response, so headers set by middleware (e.g. `Set-Cookie`, custom auth headers, `WWW-Authenticate` on reject) are no longer dropped during the handshake.

Previously, in `src/websocket.ts` the `Response` returned from `fetchCallback(...)` was inspected only for `status` — `response.headers` was discarded on both the successful and rejected paths.

## Changes

- On a successful upgrade, response headers are appended via `wss.on('headers', ...)` (the official [`ws`](https://github.com/websockets/ws) API for injecting handshake headers). The listener is removed in `finally`; `headers` is emitted synchronously inside `handleUpgrade`, so it cannot leak across concurrent upgrades on the shared `wss`.
- On a rejected upgrade, response headers are written into the manual `socket.end(...)` HTTP response produced by `rejectUpgradeRequest`.
- Skip hop-by-hop headers per [RFC 9110 Section 7.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-connection) (`connection`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailer`, `transfer-encoding`, `upgrade`), framing (`content-length`), and WebSocket handshake headers managed by `ws` (`sec-websocket-accept`, `sec-websocket-extensions`, `sec-websocket-protocol`) to avoid corrupting the handshake.

## Tests

Two new tests in `test/websocket.test.ts`:

- A custom response header set by middleware reaches the client on a successful upgrade.
- A custom response header is preserved on a rejected (401) upgrade response.

## Verification

- `bun run test --run test/websocket.test.ts` (5/5 passing)
- `bun run format`
- `bun run lint` (pre-existing warning in `listener.ts` only, unrelated to this change)
- `bun run build`

## Context

A companion PR is open against `honojs/middleware` for the same bug in `@hono/node-ws`: honojs/middleware#1873. Since `@hono/node-ws` is being deprecated in favor of `@hono/node-server`'s built-in `upgradeWebSocket` (per honojs/middleware#1862), porting the fix here ensures the bug does not survive the migration.