### PR TITLE
fix: declare ws as optional peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,11 @@
       },
       "peerDependencies": {
         "hono": "^4",
+        "ws": "^8",
       },
+      "optionalPeers": [
+        "ws",
+      ],
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,13 @@
     "ws": "^8.19.0"
   },
   "peerDependencies": {
-    "hono": "^4"
+    "hono": "^4",
+    "ws": "^8"
+  },
+  "peerDependenciesMeta": {
+    "ws": {
+      "optional": true
+    }
   },
   "packageManager": "bun@1.2.20"
 }


### PR DESCRIPTION
## Problem

`@hono/node-server` exposes `ws` types in its public declaration files (`dist/index.d.mts`, `dist/index.d.cts`) via `import type` in `src/types.ts` and `src/websocket.ts`:

```ts
import type { WebSocketServer } from 'ws'
import type { RawData, WebSocket, WebSocketServer } from 'ws'
```

However, `ws` is only listed as a `devDependency`. This causes TypeScript consumers to fail with:

```
TS2307: Cannot find module 'ws' or its corresponding type declarations.
```

This is reproducible with pnpm / NodeNext module resolution but affects any package manager since consumers are not expected to install a package's `devDependencies`.

## Fix

Declares `ws` as an optional `peerDependency` using `peerDependenciesMeta`:

```json
"peerDependencies": {
  "hono": "^4",
  "ws": "^8"
},
"peerDependenciesMeta": {
  "ws": {
    "optional": true
  }
}
```

This way:
- Consumers using WebSocket support install `ws` themselves and TypeScript compilation succeeds
- Consumers not using WebSocket get no warnings from package managers
- `publint` passes cleanly

Closes #353