### PR TITLE
docs: Align the `ServeStaticOptions` comment with the current spec

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -7,7 +7,7 @@ import { createStreamBody } from './utils/stream'
 
 export type ServeStaticOptions<E extends Env = Env> = {
   /**
-   * Root path, relative to current working directory from which the app was started. Absolute paths are not supported.
+   * Root path. Relative path is based on current working directory from which the app was started.
    */
   root?: string
   path?: string


### PR DESCRIPTION
## What
Modified the JSDoc comment on `ServeStaticOptions.root` to current spec (relative/absolute paths are both supported).

## Why

Fix #355