### PR TITLE
Declare public type dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,13 @@
   "workspaces": {
     "": {
       "name": "@hono/node-server",
+      "dependencies": {
+        "@types/node": "^20.10.0",
+        "@types/ws": "^8.18.1",
+      },
       "devDependencies": {
         "@hono/eslint-config": "^1.0.1",
-        "@types/node": "^20.10.0",
         "@types/supertest": "^2.0.12",
-        "@types/ws": "^8.18.1",
         "@whatwg-node/fetch": "^0.9.14",
         "eslint": "^9.10.0",
         "hono": "^4.12.8",

--- a/package.json
+++ b/package.json
@@ -94,9 +94,7 @@
   },
   "devDependencies": {
     "@hono/eslint-config": "^1.0.1",
-    "@types/node": "^20.10.0",
     "@types/supertest": "^2.0.12",
-    "@types/ws": "^8.18.1",
     "@whatwg-node/fetch": "^0.9.14",
     "eslint": "^9.10.0",
     "hono": "^4.12.8",
@@ -108,6 +106,10 @@
     "typescript": "^5.3.2",
     "vitest": "^4.0.18",
     "ws": "^8.19.0"
+  },
+  "dependencies": {
+    "@types/node": "^20.10.0",
+    "@types/ws": "^8.18.1"
   },
   "peerDependencies": {
     "hono": "^4"


### PR DESCRIPTION
## Summary

- move `@types/ws` into `dependencies` because the published root declarations import from `ws`
- move `@types/node` into `dependencies` because the published declarations also expose Node built-in server/request types
- update `bun.lock` accordingly

## Verification

- Reproduced the current published package failure in a clean consumer project with only `typescript`, `hono`, and `@hono/node-server@2.0.3` installed:
  - `npx tsc -p tsconfig.json` reports `TS2307: Cannot find module 'ws' or its corresponding type declarations`, plus missing Node type declarations.
- Packed this branch locally and installed it into a clean consumer project with only `typescript`, `hono`, and the local `@hono/node-server` tarball installed:
  - `npx tsc -p tsconfig.json` passes.
- `bun run build` passes, including `publint`.
- `git diff --check` passes.

Note: I also tried `bun test --run`, but the local full suite fails/hangs in unrelated Bun runtime HTTP/WebSocket cases on this machine (for example `readWithoutBlocking > should return the body for large text` and several abort/WebSocket timeout cases). The packaging/type-surface repro above is scoped to this issue.

I used an AI coding assistant to prepare this patch.

Fixes #353
