### PR TITLE
fix(serve-static): serve precompressed files for application/octet-stream

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -108,7 +108,12 @@ export const serveStatic = <E extends Env = any>(
     const mimeType = getMimeType(path)
     c.header('Content-Type', mimeType || 'application/octet-stream')
 
-    if (options.precompressed && (!mimeType || COMPRESSIBLE_CONTENT_TYPE_REGEX.test(mimeType))) {
+    if (
+      options.precompressed &&
+      (!mimeType ||
+        mimeType === 'application/octet-stream' ||
+        COMPRESSIBLE_CONTENT_TYPE_REGEX.test(mimeType))
+    ) {
       const acceptEncodingSet = new Set(
         c.req
           .header('Accept-Encoding')

--- a/test/assets/static-with-precompressed/hello.bin
+++ b/test/assets/static-with-precompressed/hello.bin
@@ -1,0 +1,1 @@
+Hello Not Compressed

--- a/test/assets/static-with-precompressed/hello.bin.br
+++ b/test/assets/static-with-precompressed/hello.bin.br
@@ -1,0 +1,1 @@
+Hello br Compressed

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -277,6 +277,18 @@ describe('Serve Static Middleware', () => {
     expect(res.text).toBe('Hello Not Compressed')
   })
 
+  it('Should return a pre-compressed response for an octet-stream file - /static-with-precompressed/hello.bin', async () => {
+    const res = await request(server)
+      .get('/static-with-precompressed/hello.bin')
+      .set('Accept-Encoding', 'gzip, br, zstd')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toBe('application/octet-stream')
+    expect(res.headers['content-length']).toBe('19')
+    expect(res.headers['content-encoding']).toBe('br')
+    expect(res.headers['vary']).toBe('Accept-Encoding')
+    expect(res.body.toString()).toBe('Hello br Compressed')
+  })
+
   describe('Absolute path', () => {
     const rootPaths = [
       path.join(__dirname, 'assets'),


### PR DESCRIPTION
Fixes #360

`serveStatic({ precompressed: true })` didn't serve precompressed variants for `application/octet-stream` files like `.bin`, even when a `.br`/`.zst`/`.gz` existed. Now it does.