### PR TITLE
fix(websocket): polyfill missing ErrorEvent global

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -38,6 +38,49 @@ export const CloseEvent: typeof globalThis.CloseEvent =
     }
   }
 
+interface ErrorEventInit extends EventInit {
+  message?: string
+  filename?: string
+  lineno?: number
+  colno?: number
+  error?: unknown
+}
+
+/**
+ * Node.js has no global `ErrorEvent`, unlike `Event`/`MessageEvent`/`CloseEvent`.
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent
+ */
+export const ErrorEvent: typeof globalThis.ErrorEvent =
+  globalThis.ErrorEvent ??
+  class extends Event {
+    #eventInitDict
+
+    constructor(type: string, eventInitDict: ErrorEventInit = {}) {
+      super(type, eventInitDict)
+      this.#eventInitDict = eventInitDict
+    }
+
+    get message(): string {
+      return this.#eventInitDict.message ?? ''
+    }
+
+    get filename(): string {
+      return this.#eventInitDict.filename ?? ''
+    }
+
+    get lineno(): number {
+      return this.#eventInitDict.lineno ?? 0
+    }
+
+    get colno(): number {
+      return this.#eventInitDict.colno ?? 0
+    }
+
+    get error(): unknown {
+      return this.#eventInitDict.error ?? null
+    }
+  }
+
 const generateConnectionSymbol = () => Symbol('connection')
 
 type WaitForWebSocket = (

--- a/test/websocket.test.ts
+++ b/test/websocket.test.ts
@@ -162,4 +162,44 @@ describe('WebSocket', () => {
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }
   })
+
+  it('should call onError with the underlying error when the raw socket errors', async () => {
+    const app = new Hono()
+    const receivedError = new Error('boom')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let rawWs: any
+    const onErrorCalled = new Promise<Event>((resolve) => {
+      app.get(
+        '/ws',
+        upgradeWebSocket(() => ({
+          onOpen(_evt, ws) {
+            rawWs = ws.raw
+          },
+          onError(evt) {
+            resolve(evt)
+          },
+        }))
+      )
+    })
+
+    const { server, address } = await startServer(app)
+
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${address.port}/ws`)
+      await new Promise<void>((resolve, reject) => {
+        ws.once('open', resolve)
+        ws.once('error', reject)
+      })
+
+      rawWs.emit('error', receivedError)
+
+      const evt = await onErrorCalled
+      expect(evt).toBeInstanceOf(Event)
+      expect((evt as ErrorEvent).error).toBe(receivedError)
+
+      ws.close()
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
 })


### PR DESCRIPTION
Node.js has no global `ErrorEvent` (unlike `Event`, `MessageEvent`, and `CloseEvent`,
which are already polyfilled/native). When the underlying `ws` socket emits an
`error` event, `upgradeWebSocket`'s handler does `new ErrorEvent('error', { error })`,
which throws a `ReferenceError` on every supported Node version. That error is caught
and passed to the internal `onError` fallback instead — so the user's `onError`
handler passed to `upgradeWebSocket` is never invoked, and the original error is lost.

This adds an `ErrorEvent` polyfill following the same pattern as the existing
`CloseEvent` one, and adds a test that reproduces the bug by emitting a real
`error` event on the raw socket and asserting the user's `onError` receives it.
