### PR TITLE
perf(request): fast-path QUERY methods

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -317,10 +317,14 @@ const normalizeIncomingMethod = (method: unknown): string => {
     case 'OPTIONS':
     case 'POST':
     case 'PUT':
+    case 'QUERY':
       return method
   }
 
   const upper = method.toUpperCase()
+  // Fetch only normalizes these methods for backwards compatibility.
+  // HTTP methods are otherwise case-sensitive, so methods not in this list
+  // (including `query`) must retain their original casing.
   switch (upper) {
     case 'DELETE':
     case 'GET':


### PR DESCRIPTION
> [!NOTE]
> This is a very small optimization. It does not change behavior in any way.

Add `QUERY` to the fast path in `normalizeIncomingMethod`.

Node.js `http.createServer()` already supports receiving `QUERY` requests and exposing the method through `req.method`. Support was introduced in Node.js v22.2.0 via [nodejs/node#52701](https://github.com/nodejs/node/pull/52701) and later backported to Node.js v20.19.3.

This change avoids an unnecessary `toUpperCase()` call and makes the standardized method explicitly recognized by the normalization fast path.

`QUERY` is added only to the exact-uppercase fast path. Lowercase and mixed-case variants remain unchanged because HTTP method names are case-sensitive.