### PR TITLE
test: use a custom helper for path traversal tests

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -43,7 +43,7 @@ export class Request extends GlobalRequest {
   }
 }
 
-const newHeadersFromIncoming = (incoming: IncomingMessage | Http2ServerRequest) => {
+export const newHeadersFromIncoming = (incoming: IncomingMessage | Http2ServerRequest) => {
   const headerRecord: [string, string][] = []
   const rawHeaders = incoming.rawHeaders
   for (let i = 0, len = rawHeaders.length; i < len; i += 2) {

--- a/test/helpers/request.ts
+++ b/test/helpers/request.ts
@@ -1,0 +1,53 @@
+import { once } from 'node:events'
+import { request as requestHTTP } from 'node:http'
+import type { IncomingMessage, RequestOptions } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { Readable } from 'node:stream'
+import { newHeadersFromIncoming } from '../../src/request'
+import { GlobalResponse } from '../../src/response'
+import type { ServerType } from '../../src/types'
+
+export type ServerRequestInit = Omit<
+  RequestOptions,
+  'agent' | 'host' | 'hostname' | 'path' | 'port' | 'protocol'
+> & {
+  body?: string | Uint8Array
+  path: string
+}
+
+export const requestServer = async (
+  server: ServerType,
+  init: ServerRequestInit
+): Promise<Response> => {
+  const address = server.address() as AddressInfo | null
+  if (!address) {
+    throw new Error('Server is not listening on a TCP address')
+  }
+
+  const { body, path, ...options } = init
+  const request = requestHTTP({
+    ...options,
+    agent: false,
+    hostname: address.address,
+    path,
+    port: address.port,
+  })
+  request.end(body)
+
+  const [incoming] = (await once(request, 'response')) as [IncomingMessage]
+  const status = incoming.statusCode
+  if (!status) {
+    throw new Error('Server response did not include a status code')
+  }
+
+  const responseBody =
+    options.method?.toUpperCase() === 'HEAD' || [101, 204, 205, 304].includes(status)
+      ? null
+      : (Readable.toWeb(incoming) as ReadableStream<Uint8Array>)
+
+  return new GlobalResponse(responseBody, {
+    headers: newHeadersFromIncoming(incoming),
+    status,
+    statusText: incoming.statusMessage,
+  })
+}

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -4,6 +4,7 @@ import { chmodSync, rmSync, statSync, symlinkSync } from 'node:fs'
 import path from 'node:path'
 import { serveStatic } from './../src/serve-static'
 import { createAdaptorServer } from './../src/server'
+import { requestServer } from './helpers/request'
 
 describe('Serve Static Middleware', () => {
   const app = new Hono<{
@@ -66,6 +67,21 @@ describe('Serve Static Middleware', () => {
   )
 
   const server = createAdaptorServer(app)
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+  )
+
+  afterAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+  )
 
   it('Should return index.html', async () => {
     const res = await request(server).get('/static/')
@@ -271,7 +287,7 @@ describe('Serve Static Middleware', () => {
   })
 
   it('Should handle double dots in URL', async () => {
-    const res = await request(server).get('/static/../secret.txt')
+    const res = await requestServer(server, { method: 'GET', path: '/static/../secret.txt' })
     expect(res.status).toBe(404)
   })
 
@@ -428,18 +444,39 @@ describe('Serve Static Middleware', () => {
     const server = createAdaptorServer(app)
     app.use('/static/*', serveStatic({ root: './test/assets' }))
 
+    beforeAll(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          server.once('error', reject)
+          server.listen(0, '127.0.0.1', resolve)
+        })
+    )
+
+    afterAll(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()))
+        })
+    )
+
     it('Should prevent path traversal attacks with double dots', async () => {
-      const res = await request(server).get('/static/../secret.txt')
+      const res = await requestServer(server, { method: 'GET', path: '/static/../secret.txt' })
       expect(res.status).toBe(404)
     })
 
     it('Should prevent path traversal attacks with multiple levels', async () => {
-      const res = await request(server).get('/static/../../package.json')
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/../../package.json',
+      })
       expect(res.status).toBe(404)
     })
 
     it('Should prevent path traversal attacks with mixed separators', async () => {
-      const res = await request(server).get('/static/..\\..\\package.json')
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/..\\..\\package.json',
+      })
       expect(res.status).toBe(404)
     })
 


### PR DESCRIPTION
The test that were testing path traversal using `supertest` were not testing the proper behaviour. `supertest` uses `superagent` under the hood which automatically normalizes the path and there is no way to turn this behaviour off. This means hono was receiving normalized `/secret.txt` instead of `/static/../secret.txt`

`superagent` is full of some of these footguns, like in #368 `superagent` suddenly started doing brotli decompression in the major version without anyway to opt out, but it doesn't do zst compression. Now the test suite fixtures are testing against are 2 different types, one real brotli fixture and one fake zst fixture. 

https://e18e.dev is trying to get the ecosystem to migrate away from superagent https://github.com/e18e/ecosystem-issues/issues/257, so probably migrating away from `supertest` also makes sense

This PR introduces a small `requestServer` util that has similar interface to `fetch` built on node:http, this interface can replace like 90% of `supertest` usage in here, for the remaining we will need to add some specialized functions for things like testing HTTP/2 and TLS.

I am only replacing the affected path tests in this PR and introducing this new helper to the codebase as a cataleyist for the future migration