### PR TITLE
fix(listener): avoid uncaught error when force-closing a non-standard socket

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -65,7 +65,11 @@ const drainIncoming = (incoming: IncomingMessage | Http2ServerRequest): void => 
     cleanup()
     const socket = incoming.socket
     if (socket && !socket.destroyed) {
-      socket.destroySoon()
+      if (typeof socket.destroySoon === 'function') {
+        socket.destroySoon()
+      } else if (typeof socket.destroy === 'function') {
+        socket.destroy()
+      }
     }
   }
 

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -1,4 +1,7 @@
+import { EventEmitter } from 'node:events'
 import { createServer } from 'node:http'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { Readable } from 'node:stream'
 import { getRequestListener } from '../src/listener'
 import { GlobalRequest, Request as LightweightRequest, RequestError } from '../src/request'
 import { GlobalResponse, Response as LightweightResponse } from '../src/response'
@@ -539,6 +542,87 @@ describe('Abort request - cacheable response path', () => {
     await withTimeout(abortedPromise, 'request abort did not propagate for cacheable stream')
     expect(capturedReq?.signal.aborted).toBe(true)
     await resPromise
+  })
+})
+
+describe('Non-standard incoming request', () => {
+  class MockSocket extends EventEmitter {
+    remoteAddress = '127.0.0.1'
+    remotePort = 44936
+  }
+
+  class MockIncomingMessage extends Readable {
+    method = 'POST'
+    url = '/'
+    headers = { host: 'localhost' }
+    rawHeaders = ['host', 'localhost']
+
+    constructor(readonly socket: EventEmitter = new MockSocket()) {
+      super()
+    }
+
+    _read() {
+      // The body is never pushed and never ends, so draining cannot complete
+      // and the drain timeout is guaranteed to fire.
+    }
+  }
+
+  class MockServerResponse extends EventEmitter {
+    headersSent = false
+    writableFinished = false
+
+    writeHead() {
+      this.headersSent = true
+      return this
+    }
+
+    end() {
+      this.writableFinished = true
+      this.emit('finish')
+      this.emit('close')
+      return this
+    }
+  }
+
+  it('Should not throw when the drain timeout fires on a socket without destroySoon', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const requestListener = getRequestListener(() => new LightweightResponse('ok'))
+      await requestListener(
+        new MockIncomingMessage() as unknown as IncomingMessage,
+        new MockServerResponse() as unknown as ServerResponse
+      )
+
+      // The drain timeout fires on a timer, so a throw here is an uncatchable
+      // uncaughtException for the caller.
+      expect(() => vi.advanceTimersByTime(1_000)).not.toThrow()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('Should destroy a socket that implements destroy but not destroySoon', async () => {
+    vi.useFakeTimers()
+
+    try {
+      // Duplex-based fakes provide the standard stream teardown method only.
+      class DuplexLikeSocket extends MockSocket {
+        destroy = vi.fn()
+      }
+      const socket = new DuplexLikeSocket()
+
+      const requestListener = getRequestListener(() => new LightweightResponse('ok'))
+      await requestListener(
+        new MockIncomingMessage(socket) as unknown as IncomingMessage,
+        new MockServerResponse() as unknown as ServerResponse
+      )
+      vi.advanceTimersByTime(1_000)
+
+      expect(socket.destroy).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 


### PR DESCRIPTION
Closes #374.

`forceClose` guards with `!socket.destroyed`, which is `undefined` on any socket that is not a real `net.Socket` — so the guard passes and `socket.destroySoon()` throws. It runs on a timer, so the `TypeError` becomes an `uncaughtException` the caller cannot catch.

This feature-detects the teardown method instead:

```ts
if (typeof socket.destroySoon === 'function') {
  socket.destroySoon()
} else if (typeof socket.destroy === 'function') {
  socket.destroy()
}
```

`net.Socket` and `tls.TLSSocket` both define `destroySoon`, so real connections keep the existing graceful-close behaviour unchanged; the check only ever diverges for sockets that could not have serviced the call. `cleanup()` still runs first on every path, so the timer and listeners are released regardless of which branch is taken.

This covers both entry points into `forceClose` — the `DRAIN_TIMEOUT_MS` timer and the `MAX_DRAIN_BYTES` overrun.

Tests drive `getRequestListener` with a mocked request whose socket is a bare `EventEmitter`, matching light-my-request's `MockSocket`: one asserts the drain timeout no longer throws, the other that a socket exposing only `destroy` is still torn down.
