### PR TITLE
perf: lazily materialize request headers

### DIFF
--- a/benchmarks/fetch/README.md
+++ b/benchmarks/fetch/README.md
@@ -19,23 +19,35 @@ pnpm run benchmark
 
 ## What's Being Tested
 
-Tests three endpoints:
+Tests four endpoints:
 
 1. **Ping (GET /)**: Simple response
 2. **Query (GET /id/:id)**: Path parameter and query parameter handling
 3. **Body (POST /json)**: JSON body processing
+4. **Headers (POST /headers)**: JSON body processing plus `request.headers.get()` and response-header creation
 
 Each endpoint is tested with 500 concurrent connections for 10 seconds, measuring requests per second (Reqs/sec).
 
+## Benchmark Environment
+
+- **Machine**: Lenovo LOQ 15IRX9 (83DV)
+- **CPU**: Intel Core i5-13450HX (10 cores, 16 threads)
+- **Memory**: 24 GB
+- **OS**: Arch Linux x86_64 (kernel 7.1.6)
+- **Node.js**: 24.19.0
+
 ## Understanding Results
+
+Last updated: 2026-08-08
 
 ```
 | Benchmark         | npm            | dev            | Difference  |
 | ----------------- | -------------- | -------------- | ----------- |
-| Average           | 111,514.97     | 115,234.56     | +3.34%      |
-| Ping (GET /)      | 122,207.70     | 125,678.90     | +2.84%      |
-| Query (GET /id)   | 106,624.16     | 110,123.45     | +3.28%      |
-| Body (POST /json) | 105,713.04     | 109,901.23     | +3.96%      |
+| Average           | 80,044.29      | 82,505.86      | +3.08%      |
+| Ping (GET /)      | 96,506.07      | 96,795.17      | +0.30%      |
+| Query (GET /id)   | 91,878.51      | 91,992.57      | +0.12%      |
+| Body (POST /json) | 73,017.98      | 72,329.00      | -0.94%      |
+| Headers (POST)    | 58,774.58      | 68,906.70      | +17.24%     |
 ```
 
 - **npm**: Published npm version (`@hono/node-server`)

--- a/benchmarks/fetch/README.md
+++ b/benchmarks/fetch/README.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Benchmark to compare performance between the published npm version and local development version of @hono/node-server.
+Benchmark comparing the published npm version and local development version of @hono/node-server with srvx.
 
 This benchmark uses a basic Fetch API-based application without the Hono framework to measure the raw performance of @hono/node-server's adapter.
 
@@ -41,18 +41,20 @@ Each endpoint is tested with 500 concurrent connections for 10 seconds, measurin
 Last updated: 2026-08-09
 
 ```
-| Benchmark         | npm            | dev            | Difference  |
-| ----------------- | -------------- | -------------- | ----------- |
-| Average           | 85,426.86      | 89,117.13      | +4.32%      |
-| Ping (GET /)      | 95,338.29      | 97,649.91      | +2.42%      |
-| Query (GET /id)   | 91,903.68      | 92,684.33      | +0.85%      |
-| Body (POST /json) | 72,924.22      | 73,512.40      | +0.81%      |
-| Headers (GET)     | 81,541.25      | 92,621.86      | +13.59%     |
+| Benchmark         | @hono/node-server (2.1.0) | srvx (0.12.5, fast) | @hono/node-server (dev) | dev vs npm | dev vs srvx |
+| ----------------- | ------------------------- | ------------------- | ----------------------- | ---------- | ----------- |
+| Average           | 83,588.79                 | 89,245.89           | 88,398.73               | +5.75%     | -0.95%      |
+| Ping (GET /)      | 87,502.45                 | 97,875.62           | 96,320.69               | +10.08%    | -1.59%      |
+| Query (GET /id)   | 92,967.16                 | 89,524.22           | 93,474.95               | +0.55%     | +4.41%      |
+| Body (POST /json) | 72,621.78                 | 75,968.80           | 73,823.52               | +1.65%     | -2.82%      |
+| Headers (GET)     | 81,263.78                 | 93,614.90           | 89,975.77               | +10.72%    | -3.89%      |
 ```
 
-- **npm**: Published npm version (`@hono/node-server`)
-- **dev**: Local development version (from repository root `dist/`)
-- **Difference**: Performance difference (positive values indicate improvement, negative values indicate regression)
+- **@hono/node-server (2.1.0)**: Published npm version
+- **@hono/node-server (dev)**: Local development version (from repository root `dist/`)
+- **srvx (0.12.5, fast)**: Published npm version using its opt-in `FastResponse`
+- **dev vs npm**: Development Hono compared with published Hono
+- **dev vs srvx**: Development Hono compared with srvx
 
 ## Reference
 

--- a/benchmarks/fetch/README.md
+++ b/benchmarks/fetch/README.md
@@ -24,7 +24,7 @@ Tests four endpoints:
 1. **Ping (GET /)**: Simple response
 2. **Query (GET /id/:id)**: Path parameter and query parameter handling
 3. **Body (POST /json)**: JSON body processing
-4. **Headers (POST /headers)**: JSON body processing plus `request.headers.get()` and response-header creation
+4. **Headers (GET /headers)**: Isolated `request.headers.get()` access
 
 Each endpoint is tested with 500 concurrent connections for 10 seconds, measuring requests per second (Reqs/sec).
 
@@ -38,16 +38,16 @@ Each endpoint is tested with 500 concurrent connections for 10 seconds, measurin
 
 ## Understanding Results
 
-Last updated: 2026-08-08
+Last updated: 2026-08-09
 
 ```
 | Benchmark         | npm            | dev            | Difference  |
 | ----------------- | -------------- | -------------- | ----------- |
-| Average           | 80,044.29      | 82,505.86      | +3.08%      |
-| Ping (GET /)      | 96,506.07      | 96,795.17      | +0.30%      |
-| Query (GET /id)   | 91,878.51      | 91,992.57      | +0.12%      |
-| Body (POST /json) | 73,017.98      | 72,329.00      | -0.94%      |
-| Headers (POST)    | 58,774.58      | 68,906.70      | +17.24%     |
+| Average           | 85,426.86      | 89,117.13      | +4.32%      |
+| Ping (GET /)      | 95,338.29      | 97,649.91      | +2.42%      |
+| Query (GET /id)   | 91,903.68      | 92,684.33      | +0.85%      |
+| Body (POST /json) | 72,924.22      | 73,512.40      | +0.81%      |
+| Headers (GET)     | 81,541.25      | 92,621.86      | +13.59%     |
 ```
 
 - **npm**: Published npm version (`@hono/node-server`)

--- a/benchmarks/fetch/package.json
+++ b/benchmarks/fetch/package.json
@@ -6,6 +6,7 @@
     "benchmark": "node --experimental-strip-types scripts/bench.ts"
   },
   "dependencies": {
-    "@hono/node-server": "^2.1.0"
+    "@hono/node-server": "^2.1.0",
+    "srvx": "^0.12.5"
   }
 }

--- a/benchmarks/fetch/package.json
+++ b/benchmarks/fetch/package.json
@@ -6,7 +6,6 @@
     "benchmark": "node --experimental-strip-types scripts/bench.ts"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.9",
-    "@hono/node-server-dev": "file:../.."
+    "@hono/node-server": "^2.1.0"
   }
 }

--- a/benchmarks/fetch/scripts/bench.ts
+++ b/benchmarks/fetch/scripts/bench.ts
@@ -218,7 +218,8 @@ async function testServer(serverFile: string, serverName: string): Promise<boole
 
 async function main(): Promise<void> {
   const servers = [
-    { file: 'src/server-npm.js', name: '@hono/node-server (npm)' },
+    { file: 'src/server-npm.js', name: '@hono/node-server (2.1.0)' },
+    { file: 'src/server-srvx.js', name: 'srvx (0.12.5, fast)' },
     { file: 'src/server-dev.js', name: '@hono/node-server (dev)' },
   ]
 
@@ -264,34 +265,37 @@ async function main(): Promise<void> {
       })
     }
 
-    const formatDiff = (npm: number, dev: number): string => {
-      const diff = ((dev - npm) / npm) * 100
-      const sign = diff > 0 ? '+' : ''
-      return `${sign}${diff.toFixed(2)}%`
+    const formatDiff = (baseline: number, dev: number): string => {
+      const diff = ((dev - baseline) / baseline) * 100
+      return `${diff > 0 ? '+' : ''}${diff.toFixed(2)}%`
     }
 
-    if (allResults.length === 2) {
-      // Comparison mode: npm vs dev
-      const npmResult = allResults.find((r) => r.server.includes('npm'))
+    if (allResults.length === 3) {
+      const npmResult = allResults.find((r) => r.server === '@hono/node-server (2.1.0)')
+      const srvxResult = allResults.find((r) => r.server === 'srvx (0.12.5, fast)')
       const devResult = allResults.find((r) => r.server.includes('dev'))
 
-      if (npmResult && devResult) {
-        console.log('| Benchmark         | npm            | dev            | Difference  |')
-        console.log('| ----------------- | -------------- | -------------- | ----------- |')
+      if (npmResult && srvxResult && devResult) {
         console.log(
-          `| Average           | ${formatNumber(npmResult.average).padEnd(14)} | ${formatNumber(devResult.average).padEnd(14)} | ${formatDiff(npmResult.average, devResult.average).padEnd(11)} |`
+          '| Benchmark         | @hono/node-server (2.1.0) | srvx (0.12.5, fast) | @hono/node-server (dev) | dev vs npm | dev vs srvx |'
         )
         console.log(
-          `| Ping (GET /)      | ${formatNumber(npmResult.ping).padEnd(14)} | ${formatNumber(devResult.ping).padEnd(14)} | ${formatDiff(npmResult.ping, devResult.ping).padEnd(11)} |`
+          '| ----------------- | ------------------------- | ------------------- | ----------------------- | ---------- | ----------- |'
         )
         console.log(
-          `| Query (GET /id)   | ${formatNumber(npmResult.query).padEnd(14)} | ${formatNumber(devResult.query).padEnd(14)} | ${formatDiff(npmResult.query, devResult.query).padEnd(11)} |`
+          `| Average           | ${formatNumber(npmResult.average).padEnd(25)} | ${formatNumber(srvxResult.average).padEnd(19)} | ${formatNumber(devResult.average).padEnd(23)} | ${formatDiff(npmResult.average, devResult.average).padEnd(10)} | ${formatDiff(srvxResult.average, devResult.average).padEnd(11)} |`
         )
         console.log(
-          `| Body (POST /json) | ${formatNumber(npmResult.body).padEnd(14)} | ${formatNumber(devResult.body).padEnd(14)} | ${formatDiff(npmResult.body, devResult.body).padEnd(11)} |`
+          `| Ping (GET /)      | ${formatNumber(npmResult.ping).padEnd(25)} | ${formatNumber(srvxResult.ping).padEnd(19)} | ${formatNumber(devResult.ping).padEnd(23)} | ${formatDiff(npmResult.ping, devResult.ping).padEnd(10)} | ${formatDiff(srvxResult.ping, devResult.ping).padEnd(11)} |`
         )
         console.log(
-          `| Headers (GET)     | ${formatNumber(npmResult.headers).padEnd(14)} | ${formatNumber(devResult.headers).padEnd(14)} | ${formatDiff(npmResult.headers, devResult.headers).padEnd(11)} |`
+          `| Query (GET /id)   | ${formatNumber(npmResult.query).padEnd(25)} | ${formatNumber(srvxResult.query).padEnd(19)} | ${formatNumber(devResult.query).padEnd(23)} | ${formatDiff(npmResult.query, devResult.query).padEnd(10)} | ${formatDiff(srvxResult.query, devResult.query).padEnd(11)} |`
+        )
+        console.log(
+          `| Body (POST /json) | ${formatNumber(npmResult.body).padEnd(25)} | ${formatNumber(srvxResult.body).padEnd(19)} | ${formatNumber(devResult.body).padEnd(23)} | ${formatDiff(npmResult.body, devResult.body).padEnd(10)} | ${formatDiff(srvxResult.body, devResult.body).padEnd(11)} |`
+        )
+        console.log(
+          `| Headers (GET)     | ${formatNumber(npmResult.headers).padEnd(25)} | ${formatNumber(srvxResult.headers).padEnd(19)} | ${formatNumber(devResult.headers).padEnd(23)} | ${formatDiff(npmResult.headers, devResult.headers).padEnd(10)} | ${formatDiff(srvxResult.headers, devResult.headers).padEnd(11)} |`
         )
       }
     } else {

--- a/benchmarks/fetch/scripts/bench.ts
+++ b/benchmarks/fetch/scripts/bench.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { once } from 'node:events'
 import { setTimeout } from 'node:timers/promises'
 
 const PORT = 3000
@@ -16,6 +17,7 @@ interface ServerResult {
   ping: number
   query: number
   body: number
+  headers: number
 }
 
 async function waitForServer(): Promise<void> {
@@ -42,6 +44,15 @@ async function retryFetch(url: string, options?: RequestInit, retries = 0): Prom
     await setTimeout(200)
     return retryFetch(url, options, retries + 1)
   }
+}
+
+async function stopServer(server: ReturnType<typeof spawn>): Promise<void> {
+  if (server.exitCode !== null || server.signalCode !== null) {
+    return
+  }
+  const exited = once(server, 'exit')
+  server.kill('SIGKILL')
+  await exited
 }
 
 async function testEndpoints(): Promise<void> {
@@ -75,6 +86,28 @@ async function testEndpoints(): Promise<void> {
       `Body: Result not match - expected ${JSON.stringify(body)}, got ${JSON.stringify(json3)}`
     )
   }
+
+  // Test incoming request-header access alongside JSON body processing.
+  const res4 = await retryFetch('http://127.0.0.1:3000/headers', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-test': '123',
+    },
+    body: JSON.stringify(body),
+  })
+  const json4 = await res4.json()
+  if (res4.status !== 200 || JSON.stringify(json4) !== JSON.stringify(body)) {
+    throw new Error(
+      `Headers: Result not match - expected ${JSON.stringify(body)}, got ${JSON.stringify(json4)}`
+    )
+  }
+  if (res4.headers.get('content-type') !== 'application/json;charset=UTF-8') {
+    throw new Error('Headers: Content-Type not match')
+  }
+  if (res4.headers.get('x-test') !== '123') {
+    throw new Error('Headers: X-Test not match')
+  }
 }
 
 async function runBenchmarkForServer(
@@ -102,6 +135,7 @@ async function runBenchmarkForServer(
       { name: 'GET /', url: 'http://127.0.0.1:3000/' },
       { name: 'GET /id/:id', url: 'http://127.0.0.1:3000/id/1?name=bun' },
       { name: 'POST /json', url: 'http://127.0.0.1:3000/json', method: 'POST' },
+      { name: 'POST /headers', url: 'http://127.0.0.1:3000/headers', method: 'POST' },
     ]
 
     const results: BenchmarkResult[] = []
@@ -110,6 +144,9 @@ async function runBenchmarkForServer(
       const args = ['--fasthttp', '-c', '500', '-d', '10s']
       if (bench.method === 'POST') {
         args.push('-m', 'POST', '-H', 'Content-Type:application/json', '-f', './scripts/body.json')
+      }
+      if (bench.name === 'POST /headers') {
+        args.push('-H', 'x-test:123')
       }
       args.push(bench.url)
 
@@ -147,7 +184,8 @@ async function runBenchmarkForServer(
     const ping = results[0]?.reqsPerSec || 0
     const query = results[1]?.reqsPerSec || 0
     const body = results[2]?.reqsPerSec || 0
-    const average = (ping + query + body) / 3
+    const headers = results[3]?.reqsPerSec || 0
+    const average = (ping + query + body + headers) / 4
 
     return {
       server: serverName,
@@ -156,14 +194,14 @@ async function runBenchmarkForServer(
       ping,
       query,
       body,
+      headers,
     }
   } catch (error) {
     console.error('Error:', (error as Error).message)
     throw error
   } finally {
     console.log('Stopping server...')
-    server.kill()
-    await setTimeout(1000)
+    await stopServer(server)
   }
 }
 
@@ -185,8 +223,7 @@ async function testServer(serverFile: string, serverName: string): Promise<boole
     console.log('  ', (error as Error)?.message || error)
     return false
   } finally {
-    server.kill()
-    await setTimeout(1000)
+    await stopServer(server)
   }
 }
 
@@ -264,21 +301,24 @@ async function main(): Promise<void> {
         console.log(
           `| Body (POST /json) | ${formatNumber(npmResult.body).padEnd(14)} | ${formatNumber(devResult.body).padEnd(14)} | ${formatDiff(npmResult.body, devResult.body).padEnd(11)} |`
         )
+        console.log(
+          `| Headers (POST)    | ${formatNumber(npmResult.headers).padEnd(14)} | ${formatNumber(devResult.headers).padEnd(14)} | ${formatDiff(npmResult.headers, devResult.headers).padEnd(11)} |`
+        )
       }
     } else {
       // Fallback: original table format
       console.log(
-        '|  Server                    | Runtime | Average      | Ping         | Query        | Body         |'
+        '|  Server                    | Runtime | Average      | Ping         | Query        | Body         | Headers      |'
       )
       console.log(
-        '| -------------------------- | ------- | ------------ | ------------ | ------------ | ------------ |'
+        '| -------------------------- | ------- | ------------ | ------------ | ------------ | ------------ | ------------ |'
       )
 
       const sortedResults = allResults.sort((a, b) => b.average - a.average)
 
       for (const result of sortedResults) {
         console.log(
-          `| ${result.server.padEnd(26)} | ${result.runtime.padEnd(7)} | ${formatNumber(result.average).padEnd(12)} | ${formatNumber(result.ping).padEnd(12)} | ${formatNumber(result.query).padEnd(12)} | ${formatNumber(result.body).padEnd(12)} |`
+          `| ${result.server.padEnd(26)} | ${result.runtime.padEnd(7)} | ${formatNumber(result.average).padEnd(12)} | ${formatNumber(result.ping).padEnd(12)} | ${formatNumber(result.query).padEnd(12)} | ${formatNumber(result.body).padEnd(12)} | ${formatNumber(result.headers).padEnd(12)} |`
         )
       }
     }

--- a/benchmarks/fetch/scripts/bench.ts
+++ b/benchmarks/fetch/scripts/bench.ts
@@ -87,26 +87,15 @@ async function testEndpoints(): Promise<void> {
     )
   }
 
-  // Test incoming request-header access alongside JSON body processing.
+  // Test an isolated incoming request-header read.
   const res4 = await retryFetch('http://127.0.0.1:3000/headers', {
-    method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
       'x-test': '123',
     },
-    body: JSON.stringify(body),
   })
-  const json4 = await res4.json()
-  if (res4.status !== 200 || JSON.stringify(json4) !== JSON.stringify(body)) {
-    throw new Error(
-      `Headers: Result not match - expected ${JSON.stringify(body)}, got ${JSON.stringify(json4)}`
-    )
-  }
-  if (res4.headers.get('content-type') !== 'application/json;charset=UTF-8') {
-    throw new Error('Headers: Content-Type not match')
-  }
-  if (res4.headers.get('x-test') !== '123') {
-    throw new Error('Headers: X-Test not match')
+  const text4 = await res4.text()
+  if (res4.status !== 200 || text4 !== '123') {
+    throw new Error(`Headers: Result not match - expected "123", got "${text4}"`)
   }
 }
 
@@ -135,7 +124,7 @@ async function runBenchmarkForServer(
       { name: 'GET /', url: 'http://127.0.0.1:3000/' },
       { name: 'GET /id/:id', url: 'http://127.0.0.1:3000/id/1?name=bun' },
       { name: 'POST /json', url: 'http://127.0.0.1:3000/json', method: 'POST' },
-      { name: 'POST /headers', url: 'http://127.0.0.1:3000/headers', method: 'POST' },
+      { name: 'GET /headers', url: 'http://127.0.0.1:3000/headers' },
     ]
 
     const results: BenchmarkResult[] = []
@@ -145,7 +134,7 @@ async function runBenchmarkForServer(
       if (bench.method === 'POST') {
         args.push('-m', 'POST', '-H', 'Content-Type:application/json', '-f', './scripts/body.json')
       }
-      if (bench.name === 'POST /headers') {
+      if (bench.name === 'GET /headers') {
         args.push('-H', 'x-test:123')
       }
       args.push(bench.url)
@@ -302,7 +291,7 @@ async function main(): Promise<void> {
           `| Body (POST /json) | ${formatNumber(npmResult.body).padEnd(14)} | ${formatNumber(devResult.body).padEnd(14)} | ${formatDiff(npmResult.body, devResult.body).padEnd(11)} |`
         )
         console.log(
-          `| Headers (POST)    | ${formatNumber(npmResult.headers).padEnd(14)} | ${formatNumber(devResult.headers).padEnd(14)} | ${formatDiff(npmResult.headers, devResult.headers).padEnd(11)} |`
+          `| Headers (GET)     | ${formatNumber(npmResult.headers).padEnd(14)} | ${formatNumber(devResult.headers).padEnd(14)} | ${formatDiff(npmResult.headers, devResult.headers).padEnd(11)} |`
         )
       }
     } else {

--- a/benchmarks/fetch/src/app.js
+++ b/benchmarks/fetch/src/app.js
@@ -9,6 +9,8 @@ export default {
         switch (url.pathname) {
           case '/':
             return new Response('Hi')
+          case '/headers':
+            return new Response(request.headers.get('x-test'))
         }
 
         if (url.pathname.startsWith('/id/')) {
@@ -27,16 +29,6 @@ export default {
 
       case 'POST':
         switch (url.pathname) {
-          case '/headers': {
-            const body = await request.json()
-            return new Response(JSON.stringify(body), {
-              headers: {
-                'x-test': request.headers.get('x-test'),
-                'content-type': 'application/json;charset=UTF-8',
-              },
-            })
-          }
-
           case '/json':
             return Response.json(await request.json())
 

--- a/benchmarks/fetch/src/app.js
+++ b/benchmarks/fetch/src/app.js
@@ -27,6 +27,16 @@ export default {
 
       case 'POST':
         switch (url.pathname) {
+          case '/headers': {
+            const body = await request.json()
+            return new Response(JSON.stringify(body), {
+              headers: {
+                'x-test': request.headers.get('x-test'),
+                'content-type': 'application/json;charset=UTF-8',
+              },
+            })
+          }
+
           case '/json':
             return Response.json(await request.json())
 

--- a/benchmarks/fetch/src/server-dev.js
+++ b/benchmarks/fetch/src/server-dev.js
@@ -1,4 +1,4 @@
-import { serve } from '@hono/node-server-dev'
+import { serve } from '../../../dist/index.mjs'
 import app from './app.js'
 
 const port = 3000

--- a/benchmarks/fetch/src/server-srvx.js
+++ b/benchmarks/fetch/src/server-srvx.js
@@ -1,0 +1,12 @@
+import { FastResponse, serve } from 'srvx'
+import app from './app.js'
+
+const port = 3000
+
+// opt into srvx fast response, since hono uses request/response shims by default
+globalThis.Response = FastResponse
+
+serve({
+  fetch: app.fetch,
+  port,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@hono/node-server':
         specifier: ^2.1.0
         version: 2.1.0(hono@4.12.8)
+      srvx:
+        specifier: ^0.12.5
+        version: 0.12.5
 
 packages:
 
@@ -2368,6 +2371,11 @@ packages:
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  srvx@0.12.5:
+    resolution: {integrity: sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
@@ -4920,6 +4928,8 @@ snapshots:
       spdx-license-ids: 3.0.23
 
   spdx-license-ids@3.0.23: {}
+
+  srvx@0.12.5: {}
 
   stable-hash-x@0.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,11 +51,8 @@ importers:
   benchmarks/fetch:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.9
-        version: 1.19.14(hono@4.12.8)
-      '@hono/node-server-dev':
-        specifier: file:../..
-        version: '@hono/node-server@file:(hono@4.12.8)'
+        specifier: ^2.1.0
+        version: 2.1.0(hono@4.12.8)
 
 packages:
 
@@ -141,14 +138,8 @@ packages:
       eslint: ^9.0.0
       typescript: ^5.0.0
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
-  '@hono/node-server@file:':
-    resolution: {directory: '', type: directory}
+  '@hono/node-server@2.1.0':
+    resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
@@ -2900,11 +2891,7 @@ snapshots:
       - eslint-plugin-import
       - supports-color
 
-  '@hono/node-server@1.19.14(hono@4.12.8)':
-    dependencies:
-      hono: 4.12.8
-
-  '@hono/node-server@file:(hono@4.12.8)':
+  '@hono/node-server@2.1.0(hono@4.12.8)':
     dependencies:
       hono: 4.12.8
 

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -4,8 +4,6 @@ import type { Http2ServerRequest } from 'node:http2'
 type IncomingHeadersSource = Pick<IncomingMessage | Http2ServerRequest, 'rawHeaders'> & {
   headers?: Record<string, string | string[] | undefined>
 }
-const incomingHeadersKey = Symbol('incomingHeaders')
-type IncomingHeadersInit = { [incomingHeadersKey]: IncomingHeadersSource }
 
 // Node keeps only the first occurrence of these headers in `incoming.headers`,
 // while WHATWG Headers combines repeated values. Fall back to rawHeaders when
@@ -56,27 +54,12 @@ const materializeHeaders = (
   return headers
 }
 
-export class Headers {
+export class RequestHeaders {
   #incoming: IncomingHeadersSource
   #headers?: GlobalHeaders
 
-  constructor(init?: HeadersInit | IncomingHeadersInit) {
-    if (init && typeof init === 'object' && incomingHeadersKey in init) {
-      this.#incoming = init[incomingHeadersKey]
-    } else {
-      // When installed as global.Headers, ordinary `new Headers(init)` calls
-      // still need native constructor semantics. Only incoming Node headers
-      // have a source that can be read lazily.
-      this.#incoming = { rawHeaders: [] }
-      this.#headers = new GlobalHeaders(init as HeadersInit | undefined)
-    }
-  }
-
-  // Native Headers created before the global replacement must remain
-  // `instanceof Headers`. This also covers this facade because its prototype
-  // inherits from GlobalHeaders.prototype.
-  static [Symbol.hasInstance](value: unknown): boolean {
-    return value instanceof GlobalHeaders
+  constructor(incoming: IncomingHeadersSource) {
+    this.#incoming = incoming
   }
 
   get #native(): GlobalHeaders {
@@ -153,14 +136,7 @@ export class Headers {
   }
 
   getSetCookie(): string[] {
-    if (this.#headers) {
-      return this.#headers.getSetCookie()
-    }
-    const value = this.#incoming.headers?.['set-cookie']
-    if (Array.isArray(value)) {
-      return value.slice()
-    }
-    return value ? [value] : this.#incoming.headers ? [] : this.#native.getSetCookie()
+    return this.#native.getSetCookie()
   }
 
   keys(): HeadersIterator<string> {
@@ -189,20 +165,16 @@ export class Headers {
   }
 }
 
-Object.defineProperty(Headers.prototype, Symbol.for('nodejs.util.inspect.custom'), {
-  value: function (this: Headers, depth: number, options: object, inspectFn: Function) {
+Object.defineProperty(RequestHeaders.prototype, Symbol.for('nodejs.util.inspect.custom'), {
+  value: function (this: RequestHeaders, depth: number, options: object, inspectFn: Function) {
     const props = Object.fromEntries(this)
     return `Headers (lightweight) ${inspectFn(props, { ...options, depth: depth == null ? null : depth - 1 })}`
   },
 })
 
-// Match the native constructor hierarchy so static properties are inherited.
-Object.setPrototypeOf(Headers, GlobalHeaders)
-// Match the native instance hierarchy so both facades and native instances
-// satisfy the expected Headers instanceof checks.
-Object.setPrototypeOf(Headers.prototype, GlobalHeaders.prototype)
+// Keep request headers compatible with the global Headers constructor without
+// replacing it for application-created and response headers.
+Object.setPrototypeOf(RequestHeaders.prototype, GlobalHeaders.prototype)
 
 export const newHeadersFromIncoming = (incoming: IncomingHeadersSource): GlobalHeaders =>
-  global.Headers === Headers
-    ? (new Headers({ [incomingHeadersKey]: incoming }) as unknown as GlobalHeaders)
-    : materializeHeaders(incoming)
+  new RequestHeaders(incoming) as unknown as GlobalHeaders

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,208 @@
+import type { IncomingMessage } from 'node:http'
+import type { Http2ServerRequest } from 'node:http2'
+
+type IncomingHeadersSource = Pick<IncomingMessage | Http2ServerRequest, 'rawHeaders'> & {
+  headers?: Record<string, string | string[] | undefined>
+}
+const incomingHeadersKey = Symbol('incomingHeaders')
+type IncomingHeadersInit = { [incomingHeadersKey]: IncomingHeadersSource }
+
+// Node keeps only the first occurrence of these headers in `incoming.headers`,
+// while WHATWG Headers combines repeated values. Fall back to rawHeaders when
+// one of them is actually repeated.
+// https://nodejs.org/api/http.html#messageheaders
+// https://github.com/nodejs/node/blob/v26.7.0/lib/_http_incoming.js
+// https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2
+const nonJoinedHeaders = new Set([
+  'age',
+  'authorization',
+  'content-length',
+  'content-type',
+  'etag',
+  'expires',
+  'from',
+  'host',
+  'if-modified-since',
+  'if-unmodified-since',
+  'last-modified',
+  'location',
+  'max-forwards',
+  'proxy-authorization',
+  'referer',
+  'retry-after',
+  'server',
+  'user-agent',
+])
+
+// Converted from RFC 9110's `field-name = token` and `token`/`tchar` ABNF.
+// https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1
+// https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2
+const validHeaderName = /^[!#$%&'*+\-.^_`|~\dA-Za-z]+$/
+
+export const GlobalHeaders = globalThis.Headers
+export type GlobalHeaders = InstanceType<typeof GlobalHeaders>
+
+const materializeHeaders = (
+  incoming: Pick<IncomingMessage | Http2ServerRequest, 'rawHeaders'>
+): GlobalHeaders => {
+  const headers = new GlobalHeaders()
+  const rawHeaders = incoming.rawHeaders
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    const name = rawHeaders[i]
+    if (!name.startsWith(':')) {
+      headers.append(name, rawHeaders[i + 1])
+    }
+  }
+  return headers
+}
+
+export class Headers {
+  #incoming: IncomingHeadersSource
+  #headers?: GlobalHeaders
+
+  constructor(init?: HeadersInit | IncomingHeadersInit) {
+    if (init && typeof init === 'object' && incomingHeadersKey in init) {
+      this.#incoming = init[incomingHeadersKey]
+    } else {
+      // When installed as global.Headers, ordinary `new Headers(init)` calls
+      // still need native constructor semantics. Only incoming Node headers
+      // have a source that can be read lazily.
+      this.#incoming = { rawHeaders: [] }
+      this.#headers = new GlobalHeaders(init as HeadersInit | undefined)
+    }
+  }
+
+  // Native Headers created before the global replacement must remain
+  // `instanceof Headers`. This also covers this facade because its prototype
+  // inherits from GlobalHeaders.prototype.
+  static [Symbol.hasInstance](value: unknown): boolean {
+    return value instanceof GlobalHeaders
+  }
+
+  get #native(): GlobalHeaders {
+    if (!this.#headers) {
+      this.#headers = materializeHeaders(this.#incoming)
+    }
+    return this.#headers
+  }
+
+  #normalizedName(name: string): string | undefined {
+    if (typeof name !== 'string') {
+      return
+    }
+    const lowerName = name.toLowerCase()
+    return validHeaderName.test(name) && lowerName !== '__proto__' ? lowerName : undefined
+  }
+
+  append(name: string, value: string): void {
+    this.#native.append(name, value)
+  }
+
+  delete(name: string): void {
+    this.#native.delete(name)
+  }
+
+  get(name: string): string | null {
+    if (this.#headers) {
+      return this.#native.get(name)
+    }
+
+    const lowerName = this.#normalizedName(name)
+    if (!lowerName) {
+      return this.#native.get(name)
+    }
+
+    const value = this.#incoming.headers?.[lowerName]
+    if (typeof value === 'string') {
+      if (nonJoinedHeaders.has(lowerName)) {
+        let found = false
+        for (let i = 0; i < this.#incoming.rawHeaders.length; i += 2) {
+          const rawName = this.#incoming.rawHeaders[i]
+          if (rawName.length === lowerName.length && rawName.toLowerCase() === lowerName) {
+            if (found) {
+              return this.#native.get(name)
+            }
+            found = true
+          }
+        }
+      }
+      return value
+    }
+    if (Array.isArray(value)) {
+      return value.join(', ')
+    }
+    return this.#incoming.headers ? null : this.#native.get(name)
+  }
+
+  has(name: string): boolean {
+    if (this.#headers) {
+      return this.#native.has(name)
+    }
+
+    const lowerName = this.#normalizedName(name)
+    if (!lowerName) {
+      return this.#native.has(name)
+    }
+    return this.#incoming.headers
+      ? Object.hasOwn(this.#incoming.headers, lowerName)
+      : this.#native.has(name)
+  }
+
+  set(name: string, value: string): void {
+    this.#native.set(name, value)
+  }
+
+  getSetCookie(): string[] {
+    if (this.#headers) {
+      return this.#headers.getSetCookie()
+    }
+    const value = this.#incoming.headers?.['set-cookie']
+    if (Array.isArray(value)) {
+      return value.slice()
+    }
+    return value ? [value] : this.#incoming.headers ? [] : this.#native.getSetCookie()
+  }
+
+  keys(): HeadersIterator<string> {
+    return this.#native.keys()
+  }
+
+  values(): HeadersIterator<string> {
+    return this.#native.values()
+  }
+
+  entries(): HeadersIterator<[string, string]> {
+    return this.#native.entries()
+  }
+
+  forEach(
+    callback: (value: string, key: string, parent: GlobalHeaders) => void,
+    thisArg?: unknown
+  ): void {
+    this.#native.forEach((value, key) => {
+      callback.call(thisArg, value, key, this as unknown as GlobalHeaders)
+    })
+  }
+
+  [Symbol.iterator](): HeadersIterator<[string, string]> {
+    return this.entries()
+  }
+}
+
+Object.defineProperty(Headers.prototype, Symbol.for('nodejs.util.inspect.custom'), {
+  value: function (this: Headers, depth: number, options: object, inspectFn: Function) {
+    const props = Object.fromEntries(this)
+    return `Headers (lightweight) ${inspectFn(props, { ...options, depth: depth == null ? null : depth - 1 })}`
+  },
+})
+
+// Match the native constructor hierarchy so static properties are inherited.
+Object.setPrototypeOf(Headers, GlobalHeaders)
+// Match the native instance hierarchy so both facades and native instances
+// satisfy the expected Headers instanceof checks.
+Object.setPrototypeOf(Headers.prototype, GlobalHeaders.prototype)
+
+export const newHeadersFromIncoming = (incoming: IncomingHeadersSource): GlobalHeaders =>
+  global.Headers === Headers
+    ? (new Headers({ [incomingHeadersKey]: incoming }) as unknown as GlobalHeaders)
+    : materializeHeaders(incoming)

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,13 +1,14 @@
 import type { IncomingMessage } from 'node:http'
-import type { Http2ServerRequest } from 'node:http2'
+import { Http2ServerRequest } from 'node:http2'
 
 type IncomingHeadersSource = Pick<IncomingMessage | Http2ServerRequest, 'rawHeaders'> & {
-  headers?: Record<string, string | string[] | undefined>
+  headers?: IncomingMessage['headers']
 }
 
-// Node keeps only the first occurrence of these headers in `incoming.headers`,
-// while WHATWG Headers combines repeated values. Fall back to rawHeaders when
-// one of them is actually repeated.
+// Node's HTTP/1 parser already joins ordinary repeated headers with the same
+// separators as WHATWG Headers, so its parsed object is a safe fast path for
+// those names. It discards repeats of this fixed set by default, however, and
+// HTTP/2 has different collapsing rules; resolve those cases from rawHeaders.
 // https://nodejs.org/api/http.html#messageheaders
 // https://github.com/nodejs/node/blob/v26.7.0/lib/_http_incoming.js
 // https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2
@@ -37,14 +38,37 @@ const nonJoinedHeaders = new Set([
 // https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2
 const validHeaderName = /^[!#$%&'*+\-.^_`|~\dA-Za-z]+$/
 
+const isHttpWhitespace = (code: number): boolean =>
+  code === 0x09 || code === 0x0a || code === 0x0d || code === 0x20
+
+const normalizeHeaderValue = (value: string): string => {
+  if (
+    !isHttpWhitespace(value.charCodeAt(0)) &&
+    !isHttpWhitespace(value.charCodeAt(value.length - 1))
+  ) {
+    return value
+  }
+  let start = 0
+  let end = value.length
+  while (start < end && isHttpWhitespace(value.charCodeAt(start))) {
+    start++
+  }
+  while (end > start && isHttpWhitespace(value.charCodeAt(end - 1))) {
+    end--
+  }
+  return value.slice(start, end)
+}
+
+const forbiddenHeaderValue = /[\0\r\n]/
+
 export const GlobalHeaders = globalThis.Headers
 export type GlobalHeaders = InstanceType<typeof GlobalHeaders>
 
 const materializeHeaders = (
-  incoming: Pick<IncomingMessage | Http2ServerRequest, 'rawHeaders'>
+  rawHeaders: string[],
+  HeadersCtor: typeof GlobalHeaders = GlobalHeaders
 ): GlobalHeaders => {
-  const headers = new GlobalHeaders()
-  const rawHeaders = incoming.rawHeaders
+  const headers = new HeadersCtor()
   for (let i = 0; i < rawHeaders.length; i += 2) {
     const name = rawHeaders[i]
     if (!name.startsWith(':')) {
@@ -56,15 +80,25 @@ const materializeHeaders = (
 
 export class RequestHeaders {
   #incoming: IncomingHeadersSource
+  #rawHeaders?: string[]
   #headers?: GlobalHeaders
+  #invalidValue?: boolean
 
   constructor(incoming: IncomingHeadersSource) {
     this.#incoming = incoming
+    if (incoming instanceof Http2ServerRequest) {
+      this.#rawHeaders = incoming.rawHeaders.slice()
+    }
+  }
+
+  get #lazyRawHeaders(): string[] {
+    return (this.#rawHeaders ??= this.#incoming.rawHeaders.slice())
   }
 
   get #native(): GlobalHeaders {
     if (!this.#headers) {
-      this.#headers = materializeHeaders(this.#incoming)
+      this.#headers = materializeHeaders(this.#lazyRawHeaders)
+      this.#rawHeaders = undefined
     }
     return this.#headers
   }
@@ -73,8 +107,54 @@ export class RequestHeaders {
     if (typeof name !== 'string') {
       return
     }
-    const lowerName = name.toLowerCase()
-    return validHeaderName.test(name) && lowerName !== '__proto__' ? lowerName : undefined
+    if (!validHeaderName.test(name)) {
+      throw new TypeError(`Invalid header name: ${name}`)
+    }
+    return name.toLowerCase()
+  }
+
+  // The HTTP/1 fast path trusts Node's parser-produced headers object. Mutating
+  // it through the incoming binding is outside this optimization's contract;
+  // detecting such changes would require scanning or copying every header.
+  #lookupHttp1(lowerName: string): string | null | undefined {
+    const headers =
+      this.#incoming instanceof Http2ServerRequest ? undefined : this.#incoming.headers
+    if (
+      !headers ||
+      nonJoinedHeaders.has(lowerName) ||
+      lowerName === 'set-cookie' ||
+      lowerName === '__proto__'
+    ) {
+      return
+    }
+
+    if (!Object.hasOwn(headers, lowerName)) {
+      return null
+    }
+    const rawValue = headers[lowerName]
+    if (typeof rawValue === 'string') {
+      const value = normalizeHeaderValue(rawValue)
+      return forbiddenHeaderValue.test(value) ? undefined : value
+    }
+    return
+  }
+
+  #lookup(rawHeaders: string[], lowerName: string): string | null | undefined {
+    const separator = lowerName === 'cookie' ? '; ' : ', '
+    let value: string | null = null
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      const rawName = rawHeaders[i]
+      if (rawName.length === lowerName.length && rawName.toLowerCase() === lowerName) {
+        const rawValue = normalizeHeaderValue(rawHeaders[i + 1])
+        if (forbiddenHeaderValue.test(rawValue)) {
+          this.#invalidValue = true
+          return
+        }
+        value = value === null ? rawValue : value + separator + rawValue
+      }
+    }
+
+    return value
   }
 
   append(name: string, value: string): void {
@@ -86,49 +166,33 @@ export class RequestHeaders {
   }
 
   get(name: string): string | null {
-    if (this.#headers) {
-      return this.#native.get(name)
-    }
-
     const lowerName = this.#normalizedName(name)
-    if (!lowerName) {
-      return this.#native.get(name)
-    }
-
-    const value = this.#incoming.headers?.[lowerName]
-    if (typeof value === 'string') {
-      if (nonJoinedHeaders.has(lowerName)) {
-        let found = false
-        for (let i = 0; i < this.#incoming.rawHeaders.length; i += 2) {
-          const rawName = this.#incoming.rawHeaders[i]
-          if (rawName.length === lowerName.length && rawName.toLowerCase() === lowerName) {
-            if (found) {
-              return this.#native.get(name)
-            }
-            found = true
-          }
-        }
+    if (lowerName && !this.#headers && !this.#invalidValue) {
+      const http1Value = this.#lookupHttp1(lowerName)
+      if (http1Value !== undefined) {
+        return http1Value
       }
-      return value
+      const value = this.#lookup(this.#lazyRawHeaders, lowerName)
+      if (value !== undefined) {
+        return value
+      }
     }
-    if (Array.isArray(value)) {
-      return value.join(', ')
-    }
-    return this.#incoming.headers ? null : this.#native.get(name)
+    return this.#native.get(name)
   }
 
   has(name: string): boolean {
-    if (this.#headers) {
-      return this.#native.has(name)
-    }
-
     const lowerName = this.#normalizedName(name)
-    if (!lowerName) {
-      return this.#native.has(name)
+    if (lowerName && !this.#headers && !this.#invalidValue) {
+      const http1Value = this.#lookupHttp1(lowerName)
+      if (http1Value !== undefined) {
+        return http1Value !== null
+      }
+      const value = this.#lookup(this.#lazyRawHeaders, lowerName)
+      if (value !== undefined) {
+        return value !== null
+      }
     }
-    return this.#incoming.headers
-      ? Object.hasOwn(this.#incoming.headers, lowerName)
-      : this.#native.has(name)
+    return this.#native.has(name)
   }
 
   set(name: string, value: string): void {
@@ -172,9 +236,14 @@ Object.defineProperty(RequestHeaders.prototype, Symbol.for('nodejs.util.inspect.
   },
 })
 
-// Keep request headers compatible with the global Headers constructor without
-// replacing it for application-created and response headers.
+// Keep request headers compatible with the captured Headers constructor so
+// `request.headers instanceof Headers` remains true without Symbol.hasInstance
+// or replacing the global constructor.
 Object.setPrototypeOf(RequestHeaders.prototype, GlobalHeaders.prototype)
 
+// Preserve the previous live-global behavior when a consumer installs a
+// Headers polyfill after this module has initialized.
 export const newHeadersFromIncoming = (incoming: IncomingHeadersSource): GlobalHeaders =>
-  new RequestHeaders(incoming) as unknown as GlobalHeaders
+  globalThis.Headers === GlobalHeaders
+    ? (new RequestHeaders(incoming) as unknown as GlobalHeaders)
+    : materializeHeaders(incoming.rawHeaders, globalThis.Headers)

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -2,7 +2,6 @@ import type { IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'node:
 import { Http2ServerRequest, constants as h2constants } from 'node:http2'
 import type { Http2ServerResponse } from 'node:http2'
 import type { Writable } from 'node:stream'
-import { Headers as LightweightHeaders } from './headers'
 import type { IncomingMessageWithWrapBodyStream } from './request'
 import {
   abortRequest,
@@ -365,9 +364,6 @@ export const getRequestListener = (
 ) => {
   const autoCleanupIncoming = options.autoCleanupIncoming ?? true
   if (options.overrideGlobalObjects !== false && global.Request !== LightweightRequest) {
-    Object.defineProperty(global, 'Headers', {
-      value: LightweightHeaders,
-    })
     Object.defineProperty(global, 'Request', {
       value: LightweightRequest,
     })

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'node:
 import { Http2ServerRequest, constants as h2constants } from 'node:http2'
 import type { Http2ServerResponse } from 'node:http2'
 import type { Writable } from 'node:stream'
+import { Headers as LightweightHeaders } from './headers'
 import type { IncomingMessageWithWrapBodyStream } from './request'
 import {
   abortRequest,
@@ -364,6 +365,9 @@ export const getRequestListener = (
 ) => {
   const autoCleanupIncoming = options.autoCleanupIncoming ?? true
   if (options.overrideGlobalObjects !== false && global.Request !== LightweightRequest) {
+    Object.defineProperty(global, 'Headers', {
+      value: LightweightHeaders,
+    })
     Object.defineProperty(global, 'Request', {
       value: LightweightRequest,
     })

--- a/src/request.ts
+++ b/src/request.ts
@@ -7,6 +7,8 @@ import { Readable } from 'node:stream'
 import type { ReadableStreamDefaultReader } from 'node:stream/web'
 import type { TLSSocket } from 'node:tls'
 import { RequestError } from './error'
+import { newHeadersFromIncoming } from './headers'
+import type { GlobalHeaders } from './headers'
 import { buildUrl } from './url'
 
 export { RequestError }
@@ -41,20 +43,6 @@ export class Request extends GlobalRequest {
     }
     super(input, options)
   }
-}
-
-export const newHeadersFromIncoming = (
-  incoming: Pick<IncomingMessage | Http2ServerRequest, 'rawHeaders'>
-) => {
-  const headerRecord: [string, string][] = []
-  const rawHeaders = incoming.rawHeaders
-  for (let i = 0, len = rawHeaders.length; i < len; i += 2) {
-    const key = rawHeaders[i]
-    if (key.charCodeAt(0) !== /*:*/ 0x3a) {
-      headerRecord.push([key, rawHeaders[i + 1]])
-    }
-  }
-  return new Headers(headerRecord)
 }
 
 export type IncomingMessageWithWrapBodyStream = IncomingMessage & { [wrapBodyStream]: boolean }
@@ -184,7 +172,7 @@ const enqueueBufferedBody = (
 const newRequestFromIncoming = (
   method: string,
   url: string,
-  headers: Headers,
+  headers: GlobalHeaders,
   incoming: IncomingMessage | Http2ServerRequest,
   abortController: AbortController
 ): Request => {

--- a/test/headers.test.ts
+++ b/test/headers.test.ts
@@ -1,4 +1,7 @@
 import type { IncomingMessage } from 'node:http'
+import { Http2ServerRequest } from 'node:http2'
+import type { ServerHttp2Stream } from 'node:http2'
+import { Duplex } from 'node:stream'
 import { inspect } from 'node:util'
 import { GlobalHeaders, RequestHeaders, newHeadersFromIncoming } from '../src/headers'
 import { newRequest, Request as LightweightRequest } from '../src/request'
@@ -6,13 +9,38 @@ import { newRequest, Request as LightweightRequest } from '../src/request'
 // Compatibility cases adapted from srvx's Node header suite:
 // https://github.com/h3js/srvx/blob/4052594e76d5ead2cc4c7cf8f7fa6d5ea9558a0a/test/node-headers.test.ts
 
-const incoming = (
+const incoming = (rawHeaders: string[], headers: Record<string, unknown>): IncomingMessage =>
+  ({ rawHeaders, headers }) as IncomingMessage
+
+const incomingHttp2 = (
   rawHeaders: string[],
   headers: Record<string, string | string[]>
-): IncomingMessage => ({ rawHeaders, headers }) as IncomingMessage
+): Http2ServerRequest =>
+  new Http2ServerRequest(new Duplex() as ServerHttp2Stream, headers, {}, rawHeaders)
 
-const lightweightHeaders = (request: IncomingMessage): GlobalHeaders =>
+const lightweightHeaders = (request: IncomingMessage | Http2ServerRequest): GlobalHeaders =>
   newHeadersFromIncoming(request)
+
+const nonJoinedHeaderNames = [
+  'age',
+  'authorization',
+  'content-length',
+  'content-type',
+  'etag',
+  'expires',
+  'from',
+  'host',
+  'if-modified-since',
+  'if-unmodified-since',
+  'last-modified',
+  'location',
+  'max-forwards',
+  'proxy-authorization',
+  'referer',
+  'retry-after',
+  'server',
+  'user-agent',
+]
 
 describe('RequestHeaders', () => {
   it('reads common headers without iterating rawHeaders', () => {
@@ -31,40 +59,99 @@ describe('RequestHeaders', () => {
     expect(headers.get('X-Test')).toBe('value')
     expect(headers.has('x-test')).toBe(true)
     expect(rawHeadersReads).toBe(0)
+    expect(() => headers.get('bad name')).toThrow(TypeError)
+    expect(() => headers.has(':path')).toThrow(TypeError)
+    expect(rawHeadersReads).toBe(0)
 
     expect([...headers]).toEqual([['x-test', 'value']])
     expect(rawHeadersReads).toBe(1)
   })
 
-  it('combines repeated headers consistently before and after iteration', () => {
-    const rawHeaders = [
-      'authorization',
-      'Bearer AAA',
-      'authorization',
-      'Bearer BBB',
-      'content-type',
-      'text/plain',
-      'content-type',
-      'application/json',
-    ]
-    const collapsed = { authorization: 'Bearer AAA', 'content-type': 'text/plain' }
+  it.each(nonJoinedHeaderNames)(
+    'combines repeated %s values consistently before and after iteration',
+    (name) => {
+      const rawHeaders = [name, 'one', name, 'two']
+      const collapsed = { [name]: 'one' }
 
-    const before = lightweightHeaders(incoming(rawHeaders, collapsed))
-    expect(before.get('authorization')).toBe('Bearer AAA, Bearer BBB')
-    expect(before.get('content-type')).toBe('text/plain, application/json')
-    expect(before.has('authorization')).toBe(true)
+      const before = lightweightHeaders(incoming(rawHeaders, collapsed))
+      expect(before.get(name)).toBe('one, two')
+      expect(before.has(name)).toBe(true)
 
-    const after = lightweightHeaders(incoming(rawHeaders, collapsed))
-    void [...after]
-    expect(after.get('authorization')).toBe('Bearer AAA, Bearer BBB')
-    expect(after.get('content-type')).toBe('text/plain, application/json')
+      const after = lightweightHeaders(incoming(rawHeaders, collapsed))
+      void [...after]
+      expect(after.get(name)).toBe('one, two')
+    }
+  )
+
+  it('combines headers collapsed by the HTTP/2 parser', () => {
+    const headers = lightweightHeaders(
+      incomingHttp2(['if-none-match', '"a"', 'if-none-match', '"b"'], {
+        'if-none-match': '"a"',
+      })
+    )
+
+    expect(headers.get('if-none-match')).toBe('"a", "b"')
+    void [...headers]
+    expect(headers.get('if-none-match')).toBe('"a", "b"')
+  })
+
+  it('uses an immutable raw-header snapshot for HTTP/2', () => {
+    const rawHeaders = ['x-secret', 'topsecret', 'host', 'localhost']
+    const request = incomingHttp2(rawHeaders, {
+      'x-secret': 'topsecret',
+      host: 'localhost',
+    })
+    const headers = lightweightHeaders(request)
+
+    delete request.headers['x-secret']
+    request.headers['x-added'] = 'value'
+    rawHeaders[1] = 'changed'
+    rawHeaders.push('x-added', 'value')
+
+    expect(headers.get('x-secret')).toBe('topsecret')
+    expect(headers.has('x-added')).toBe(false)
+    void [...headers]
+    expect(headers.get('x-secret')).toBe('topsecret')
+    expect(headers.has('x-added')).toBe(false)
+  })
+
+  it('ignores non-string values in synthesized parsed headers', () => {
+    const headers = lightweightHeaders(
+      incoming(['content-length', '123'], { 'content-length': 123 })
+    )
+
+    expect(headers.get('content-length')).toBe('123')
+    expect(headers.has('content-length')).toBe(true)
+    void [...headers]
+    expect(headers.get('content-length')).toBe('123')
+  })
+
+  it('normalizes raw values consistently before and after materialization', () => {
+    const rawHeaders = ['x-token', '  abc\t', 'x-tab', '\tv v\t', 'x-interior', 'a  b']
+    const headers = lightweightHeaders(incomingHttp2(rawHeaders, {}))
+
+    expect(headers.get('x-token')).toBe('abc')
+    expect(headers.get('x-tab')).toBe('v v')
+    expect(headers.get('x-interior')).toBe('a  b')
+    void [...headers]
+    expect(headers.get('x-token')).toBe('abc')
+    expect(headers.get('x-tab')).toBe('v v')
+    expect(headers.get('x-interior')).toBe('a  b')
+  })
+
+  it('fails closed on values rejected by native Headers', () => {
+    const rawHeaders = ['x-evil', 'ok', 'x-evil', 'bad\0value']
+
+    expect(() => lightweightHeaders(incomingHttp2(rawHeaders, {})).get('x-evil')).toThrow(TypeError)
+    expect(() => lightweightHeaders(incomingHttp2(rawHeaders, {})).has('x-evil')).toThrow(TypeError)
+    expect(() => [...lightweightHeaders(incomingHttp2(rawHeaders, {}))]).toThrow(TypeError)
   })
 
   it('preserves cookie and set-cookie representations', () => {
     const headers = lightweightHeaders(
       incoming(['cookie', 'a=1', 'cookie', 'b=2', 'set-cookie', 'a=1', 'set-cookie', 'b=2'], {
         cookie: 'a=1; b=2',
-        'set-cookie': ['a=1', 'b=2'],
+        'set-cookie': ['ignored'],
       })
     )
 
@@ -126,6 +213,26 @@ describe('RequestHeaders', () => {
     expect(Object.getPrototypeOf(headers)).toBe(RequestHeaders.prototype)
     expect(headers).toBeInstanceOf(GlobalHeaders)
     expect(new GlobalHeaders(headers).get('x-test')).toBe('value')
+  })
+
+  it('uses the live global Headers constructor when it changes after module initialization', () => {
+    class PolyfillHeaders extends GlobalHeaders {}
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'Headers')
+    Object.defineProperty(globalThis, 'Headers', {
+      value: PolyfillHeaders,
+      configurable: true,
+      writable: true,
+    })
+
+    try {
+      const headers = newHeadersFromIncoming(incoming(['x-test', 'value'], { 'x-test': 'value' }))
+
+      expect(headers).toBeInstanceOf(PolyfillHeaders)
+      expect(Object.getPrototypeOf(headers)).toBe(PolyfillHeaders.prototype)
+      expect(headers.get('x-test')).toBe('value')
+    } finally {
+      Object.defineProperty(globalThis, 'Headers', descriptor!)
+    }
   })
 
   it('can initialize and clone a native Request after header mutation', () => {

--- a/test/headers.test.ts
+++ b/test/headers.test.ts
@@ -1,10 +1,6 @@
 import type { IncomingMessage } from 'node:http'
 import { inspect } from 'node:util'
-import {
-  GlobalHeaders,
-  Headers as LightweightHeaders,
-  newHeadersFromIncoming,
-} from '../src/headers'
+import { GlobalHeaders, RequestHeaders, newHeadersFromIncoming } from '../src/headers'
 import { newRequest, Request as LightweightRequest } from '../src/request'
 
 // Compatibility cases adapted from srvx's Node header suite:
@@ -15,29 +11,10 @@ const incoming = (
   headers: Record<string, string | string[]>
 ): IncomingMessage => ({ rawHeaders, headers }) as IncomingMessage
 
-const lightweightHeaders = (request: IncomingMessage): GlobalHeaders => {
-  Object.defineProperty(global, 'Headers', {
-    value: LightweightHeaders,
-    writable: true,
-  })
-  return newHeadersFromIncoming(request)
-}
+const lightweightHeaders = (request: IncomingMessage): GlobalHeaders =>
+  newHeadersFromIncoming(request)
 
-describe('Headers', () => {
-  beforeEach(() => {
-    Object.defineProperty(global, 'Headers', {
-      value: GlobalHeaders,
-      writable: true,
-    })
-  })
-
-  afterEach(() => {
-    Object.defineProperty(global, 'Headers', {
-      value: GlobalHeaders,
-      writable: true,
-    })
-  })
-
+describe('RequestHeaders', () => {
   it('reads common headers without iterating rawHeaders', () => {
     let rawHeadersReads = 0
     const request = {
@@ -130,38 +107,28 @@ describe('Headers', () => {
     expect(inspect(headers)).toContain("Headers (lightweight) { 'x-test': 'value' }")
   })
 
-  it('supports the standard Headers constructor when installed globally', () => {
-    Object.defineProperty(global, 'Headers', {
-      value: LightweightHeaders,
-      writable: true,
-    })
-
+  it('leaves the standard Headers constructor unchanged', () => {
     const headers = new Headers({ 'x-test': 'one' })
     headers.append('x-test', 'two')
 
+    expect(global.Headers).toBe(GlobalHeaders)
+    expect(Object.getPrototypeOf(headers)).toBe(GlobalHeaders.prototype)
     expect(headers.get('x-test')).toBe('one, two')
     expect(new Headers(headers).get('x-test')).toBe('one, two')
     expect(new Headers({ rawHeaders: 'ordinary value' }).get('rawHeaders')).toBe('ordinary value')
   })
 
-  it('selects the implementation from the active global', () => {
+  it('uses the internal implementation without replacing the global constructor', () => {
     const request = incoming(['x-test', 'value'], { 'x-test': 'value' })
-    const native = newHeadersFromIncoming(request)
-    expect(Object.getPrototypeOf(native)).toBe(GlobalHeaders.prototype)
+    const headers = newHeadersFromIncoming(request)
 
-    Object.defineProperty(global, 'Headers', {
-      value: LightweightHeaders,
-      writable: true,
-    })
-    const lightweight = newHeadersFromIncoming(request)
-    expect(Object.getPrototypeOf(lightweight)).toBe(LightweightHeaders.prototype)
+    expect(global.Headers).toBe(GlobalHeaders)
+    expect(Object.getPrototypeOf(headers)).toBe(RequestHeaders.prototype)
+    expect(headers).toBeInstanceOf(GlobalHeaders)
+    expect(new GlobalHeaders(headers).get('x-test')).toBe('value')
   })
 
   it('can initialize and clone a native Request after header mutation', () => {
-    Object.defineProperty(global, 'Headers', {
-      value: LightweightHeaders,
-      writable: true,
-    })
     const request = newRequest({
       method: 'GET',
       url: '/',

--- a/test/headers.test.ts
+++ b/test/headers.test.ts
@@ -1,0 +1,178 @@
+import type { IncomingMessage } from 'node:http'
+import { inspect } from 'node:util'
+import {
+  GlobalHeaders,
+  Headers as LightweightHeaders,
+  newHeadersFromIncoming,
+} from '../src/headers'
+import { newRequest, Request as LightweightRequest } from '../src/request'
+
+// Compatibility cases adapted from srvx's Node header suite:
+// https://github.com/h3js/srvx/blob/4052594e76d5ead2cc4c7cf8f7fa6d5ea9558a0a/test/node-headers.test.ts
+
+const incoming = (
+  rawHeaders: string[],
+  headers: Record<string, string | string[]>
+): IncomingMessage => ({ rawHeaders, headers }) as IncomingMessage
+
+const lightweightHeaders = (request: IncomingMessage): GlobalHeaders => {
+  Object.defineProperty(global, 'Headers', {
+    value: LightweightHeaders,
+    writable: true,
+  })
+  return newHeadersFromIncoming(request)
+}
+
+describe('Headers', () => {
+  beforeEach(() => {
+    Object.defineProperty(global, 'Headers', {
+      value: GlobalHeaders,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(global, 'Headers', {
+      value: GlobalHeaders,
+      writable: true,
+    })
+  })
+
+  it('reads common headers without iterating rawHeaders', () => {
+    let rawHeadersReads = 0
+    const request = {
+      headers: { 'x-test': 'value' },
+      get rawHeaders() {
+        rawHeadersReads++
+        return ['x-test', 'value']
+      },
+    } as unknown as IncomingMessage
+
+    const headers = lightweightHeaders(request)
+
+    expect(headers).toBeInstanceOf(GlobalHeaders)
+    expect(headers.get('X-Test')).toBe('value')
+    expect(headers.has('x-test')).toBe(true)
+    expect(rawHeadersReads).toBe(0)
+
+    expect([...headers]).toEqual([['x-test', 'value']])
+    expect(rawHeadersReads).toBe(1)
+  })
+
+  it('combines repeated headers consistently before and after iteration', () => {
+    const rawHeaders = [
+      'authorization',
+      'Bearer AAA',
+      'authorization',
+      'Bearer BBB',
+      'content-type',
+      'text/plain',
+      'content-type',
+      'application/json',
+    ]
+    const collapsed = { authorization: 'Bearer AAA', 'content-type': 'text/plain' }
+
+    const before = lightweightHeaders(incoming(rawHeaders, collapsed))
+    expect(before.get('authorization')).toBe('Bearer AAA, Bearer BBB')
+    expect(before.get('content-type')).toBe('text/plain, application/json')
+    expect(before.has('authorization')).toBe(true)
+
+    const after = lightweightHeaders(incoming(rawHeaders, collapsed))
+    void [...after]
+    expect(after.get('authorization')).toBe('Bearer AAA, Bearer BBB')
+    expect(after.get('content-type')).toBe('text/plain, application/json')
+  })
+
+  it('preserves cookie and set-cookie representations', () => {
+    const headers = lightweightHeaders(
+      incoming(['cookie', 'a=1', 'cookie', 'b=2', 'set-cookie', 'a=1', 'set-cookie', 'b=2'], {
+        cookie: 'a=1; b=2',
+        'set-cookie': ['a=1', 'b=2'],
+      })
+    )
+
+    expect(headers.get('cookie')).toBe('a=1; b=2')
+    expect(headers.get('set-cookie')).toBe('a=1, b=2')
+    expect(headers.getSetCookie()).toEqual(['a=1', 'b=2'])
+    expect(Object.fromEntries(headers).cookie).toBe('a=1; b=2')
+  })
+
+  it('reads a literal __proto__ header without exposing prototype properties', () => {
+    const headers = lightweightHeaders(
+      incoming(['__proto__', 'value', 'x-test', 'one'], { 'x-test': 'one' })
+    )
+
+    expect(headers.get('__proto__')).toBe('value')
+    expect(headers.has('__proto__')).toBe(true)
+    expect(headers.get('toString')).toBe(null)
+    expect(headers.has('toString')).toBe(false)
+  })
+
+  it('materializes for validation and mutation while preserving identity', () => {
+    const headers = lightweightHeaders(incoming(['host', 'localhost'], { host: 'localhost' }))
+
+    expect(() => headers.get('bad name')).toThrow(TypeError)
+    expect(() => headers.has(':path')).toThrow(TypeError)
+    headers.set('x-test', 'value')
+    headers.append('x-test', 'second')
+
+    expect(headers.get('x-test')).toBe('value, second')
+    let callbackParent: GlobalHeaders | undefined
+    headers.forEach((_value, _key, parent) => {
+      callbackParent = parent
+    })
+    expect(callbackParent).toBe(headers)
+  })
+
+  it('uses the lightweight inspection format', () => {
+    const headers = lightweightHeaders(incoming(['x-test', 'value'], { 'x-test': 'value' }))
+
+    expect(inspect(headers)).toContain("Headers (lightweight) { 'x-test': 'value' }")
+  })
+
+  it('supports the standard Headers constructor when installed globally', () => {
+    Object.defineProperty(global, 'Headers', {
+      value: LightweightHeaders,
+      writable: true,
+    })
+
+    const headers = new Headers({ 'x-test': 'one' })
+    headers.append('x-test', 'two')
+
+    expect(headers.get('x-test')).toBe('one, two')
+    expect(new Headers(headers).get('x-test')).toBe('one, two')
+    expect(new Headers({ rawHeaders: 'ordinary value' }).get('rawHeaders')).toBe('ordinary value')
+  })
+
+  it('selects the implementation from the active global', () => {
+    const request = incoming(['x-test', 'value'], { 'x-test': 'value' })
+    const native = newHeadersFromIncoming(request)
+    expect(Object.getPrototypeOf(native)).toBe(GlobalHeaders.prototype)
+
+    Object.defineProperty(global, 'Headers', {
+      value: LightweightHeaders,
+      writable: true,
+    })
+    const lightweight = newHeadersFromIncoming(request)
+    expect(Object.getPrototypeOf(lightweight)).toBe(LightweightHeaders.prototype)
+  })
+
+  it('can initialize and clone a native Request after header mutation', () => {
+    Object.defineProperty(global, 'Headers', {
+      value: LightweightHeaders,
+      writable: true,
+    })
+    const request = newRequest({
+      method: 'GET',
+      url: '/',
+      headers: { host: 'localhost' },
+      rawHeaders: ['host', 'localhost'],
+    } as IncomingMessage)
+    const headers = request.headers
+    headers.set('x-test', 'value')
+
+    expect(request.keepalive).toBe(false)
+    expect(request.headers).toBe(headers)
+    expect(new LightweightRequest(request).headers.get('x-test')).toBe('value')
+  })
+})

--- a/test/helpers/request.ts
+++ b/test/helpers/request.ts
@@ -5,7 +5,7 @@ import { connect } from 'node:http2'
 import type { IncomingHttpHeaders as IncomingHttp2Headers } from 'node:http2'
 import { Server as HttpsServer, request as requestHTTPS } from 'node:https'
 import type { AddressInfo } from 'node:net'
-import { newHeadersFromIncoming } from '../../src/request'
+import { newHeadersFromIncoming } from '../../src/headers'
 import { GlobalResponse } from '../../src/response'
 import type { ServerType } from '../../src/types'
 

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events'
 import { createServer } from 'node:http'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { Readable } from 'node:stream'
-import { GlobalHeaders, Headers as LightweightHeaders } from '../src/headers'
+import { GlobalHeaders } from '../src/headers'
 import { getRequestListener } from '../src/listener'
 import { GlobalRequest, Request as LightweightRequest, RequestError } from '../src/request'
 import { GlobalResponse, Response as LightweightResponse } from '../src/response'
@@ -648,7 +648,7 @@ describe('overrideGlobalObjects', () => {
   describe('default', () => {
     it('Should be overridden', () => {
       getRequestListener(fetchCallback)
-      expect(global.Headers).toBe(LightweightHeaders)
+      expect(global.Headers).toBe(GlobalHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })
@@ -659,7 +659,7 @@ describe('overrideGlobalObjects', () => {
       getRequestListener(fetchCallback, {
         overrideGlobalObjects: true,
       })
-      expect(global.Headers).toBe(LightweightHeaders)
+      expect(global.Headers).toBe(GlobalHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })

--- a/test/listener.test.ts
+++ b/test/listener.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { createServer } from 'node:http'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { Readable } from 'node:stream'
+import { GlobalHeaders, Headers as LightweightHeaders } from '../src/headers'
 import { getRequestListener } from '../src/listener'
 import { GlobalRequest, Request as LightweightRequest, RequestError } from '../src/request'
 import { GlobalResponse, Response as LightweightResponse } from '../src/response'
@@ -630,6 +631,10 @@ describe('overrideGlobalObjects', () => {
   const fetchCallback = vi.fn()
 
   beforeEach(() => {
+    Object.defineProperty(global, 'Headers', {
+      value: GlobalHeaders,
+      writable: true,
+    })
     Object.defineProperty(global, 'Request', {
       value: GlobalRequest,
       writable: true,
@@ -643,6 +648,7 @@ describe('overrideGlobalObjects', () => {
   describe('default', () => {
     it('Should be overridden', () => {
       getRequestListener(fetchCallback)
+      expect(global.Headers).toBe(LightweightHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })
@@ -653,6 +659,7 @@ describe('overrideGlobalObjects', () => {
       getRequestListener(fetchCallback, {
         overrideGlobalObjects: true,
       })
+      expect(global.Headers).toBe(LightweightHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })
@@ -663,6 +670,7 @@ describe('overrideGlobalObjects', () => {
       getRequestListener(fetchCallback, {
         overrideGlobalObjects: false,
       })
+      expect(global.Headers).toBe(GlobalHeaders)
       expect(global.Request).toBe(GlobalRequest)
       expect(global.Response).toBe(GlobalResponse)
     })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs'
 import { createServer as createHttp2Server } from 'node:http2'
 import { createServer as createHTTPSServer } from 'node:https'
 import { gunzipSync, inflateSync } from 'node:zlib'
-import { GlobalHeaders, Headers as LightweightHeaders } from '../src/headers'
+import { GlobalHeaders } from '../src/headers'
 import { GlobalRequest, Request as LightweightRequest, getAbortController } from '../src/request'
 import { GlobalResponse, Response as LightweightResponse } from '../src/response'
 import { createAdaptorServer, serve } from '../src/server'
@@ -1122,7 +1122,7 @@ describe('overrideGlobalObjects', () => {
   describe('default', () => {
     it('Should be overridden', () => {
       createAdaptorServer(app)
-      expect(global.Headers).toBe(LightweightHeaders)
+      expect(global.Headers).toBe(GlobalHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })
@@ -1131,7 +1131,7 @@ describe('overrideGlobalObjects', () => {
   describe('overrideGlobalObjects: true', () => {
     it('Should be overridden', () => {
       createAdaptorServer({ overrideGlobalObjects: true, fetch: app.fetch })
-      expect(global.Headers).toBe(LightweightHeaders)
+      expect(global.Headers).toBe(GlobalHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs'
 import { createServer as createHttp2Server } from 'node:http2'
 import { createServer as createHTTPSServer } from 'node:https'
 import { gunzipSync, inflateSync } from 'node:zlib'
+import { GlobalHeaders, Headers as LightweightHeaders } from '../src/headers'
 import { GlobalRequest, Request as LightweightRequest, getAbortController } from '../src/request'
 import { GlobalResponse, Response as LightweightResponse } from '../src/response'
 import { createAdaptorServer, serve } from '../src/server'
@@ -1104,6 +1105,10 @@ describe('overrideGlobalObjects', () => {
   const app = new Hono()
 
   beforeEach(() => {
+    Object.defineProperty(global, 'Headers', {
+      value: GlobalHeaders,
+      writable: true,
+    })
     Object.defineProperty(global, 'Request', {
       value: GlobalRequest,
       writable: true,
@@ -1117,6 +1122,7 @@ describe('overrideGlobalObjects', () => {
   describe('default', () => {
     it('Should be overridden', () => {
       createAdaptorServer(app)
+      expect(global.Headers).toBe(LightweightHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })
@@ -1125,6 +1131,7 @@ describe('overrideGlobalObjects', () => {
   describe('overrideGlobalObjects: true', () => {
     it('Should be overridden', () => {
       createAdaptorServer({ overrideGlobalObjects: true, fetch: app.fetch })
+      expect(global.Headers).toBe(LightweightHeaders)
       expect(global.Request).toBe(LightweightRequest)
       expect(global.Response).toBe(LightweightResponse)
     })
@@ -1133,6 +1140,7 @@ describe('overrideGlobalObjects', () => {
   describe('overrideGlobalObjects: false', () => {
     it('Should not be overridden', () => {
       createAdaptorServer({ overrideGlobalObjects: false, fetch: app.fetch })
+      expect(global.Headers).toBe(GlobalHeaders)
       expect(global.Request).toBe(GlobalRequest)
       expect(global.Response).toBe(GlobalResponse)
     })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,3 +10,7 @@ Object.defineProperty(global, 'Request', {
   value: global.Request,
   writable: true,
 })
+Object.defineProperty(global, 'Headers', {
+  value: global.Headers,
+  writable: true,
+})


### PR DESCRIPTION
`@hono/node-server` constructs a native `Headers` object as soon as `req.headers` is accessed
on the other hand `srvx` returns a lightweight header like class whose common operations read `IncomingMessage.headers` directly, and constructs a native `Headers` object when the need arises. see https://github.com/h3js/srvx/blob/4052594e76d5ead2cc4c7cf8f7fa6d5ea9558a0a/src/adapters/_node/headers.ts#L53

This implements the same behaviour in `@hono/node-server` and adds a benchmark for it, this makes simpler header ops upto 20% faster on my machine.