### PR TITLE
fix: type error in early hints and add typecheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           run_install: true
       - run: pnpm run format
       - run: pnpm run lint
+      - run: pnpm run typecheck
       - run: pnpm run test
 
   ci-build:

--- a/benchmarks/fetch/tsconfig.json
+++ b/benchmarks/fetch/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "ESNext",
+    "declaration": true,
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "scripts/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "postbuild": "publint",
     "prerelease": "pnpm run build && pnpm run test --run",
     "release": "np --no-publish",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",
     "format": "prettier --check \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\"",

--- a/src/early-hints.ts
+++ b/src/early-hints.ts
@@ -27,7 +27,7 @@ export const earlyHints = <E extends Env = any>(
     }
 
     const env = c.env || {}
-    const bindings = (env.server ? env.server : env) as HttpBindings
+    const bindings = ('server' in env ? env.server : env) as HttpBindings
     const outgoing = bindings?.outgoing
 
     // Capability check: outgoing.writeEarlyHints exists and is a function.


### PR DESCRIPTION
I noticed a type error in `early-hints.ts`, looks like we don't have a typecheck command nor we run typecheck in CI.
I fixed the type error and added typecheck command and run it on CI for PRs