### PR TITLE
feat(serve-static): respond 304 for If-Modified-Since requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ app.use(
 )
 ```
 
+### Conditional Requests
+
+`serveStatic` sets the `Last-Modified` header on responses. For `GET` and `HEAD` requests carrying an `If-Modified-Since` header, it responds with `304 Not Modified` when the file has not been modified since that date, per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-if-modified-since). An `If-Modified-Since` header is ignored when `If-None-Match` is present, as the latter takes precedence.
+
 ## ConnInfo Helper
 
 You can use the [ConnInfo Helper](https://hono.dev/docs/helpers/conninfo) by importing `getConnInfo` from `@hono/node-server/conninfo`.

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -205,6 +205,11 @@ export const serveStatic = <E extends Env = any>(
       (c.req.method === 'GET' || c.req.method === 'HEAD') &&
       isNotModifiedSince(ifModifiedSince, stats.mtimeMs)
     ) {
+      // A 304 response cannot carry representation metadata, so the content
+      // headers set above are removed. `Last-Modified` and `Vary` are kept,
+      // as they exist to guide cache updates. See RFC 9110 Section 15.4.5.
+      c.header('Content-Type', undefined)
+      c.header('Content-Encoding', undefined)
       await options.onFound?.(path, c)
       return c.body(null, 304)
     }

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -190,6 +190,26 @@ export const serveStatic = <E extends Env = any>(
     const range = c.req.header('range') || ''
     c.header('Last-Modified', stats.mtime.toUTCString())
 
+    // Respond with 304 if the file has not been modified since the
+    // If-Modified-Since date. Per RFC 9110, If-Modified-Since is only used
+    // for GET/HEAD requests and is ignored when If-None-Match is present.
+    const ifModifiedSince = c.req.header('if-modified-since')
+    if (
+      ifModifiedSince &&
+      !c.req.header('if-none-match') &&
+      (c.req.method === 'GET' || c.req.method === 'HEAD')
+    ) {
+      const sinceMs = Date.parse(ifModifiedSince)
+      // HTTP dates only have second precision, so compare at second granularity
+      if (
+        !Number.isNaN(sinceMs) &&
+        Math.floor(stats.mtimeMs / 1000) <= Math.floor(sinceMs / 1000)
+      ) {
+        await options.onFound?.(path, c)
+        return c.body(null, 304)
+      }
+    }
+
     if (c.req.method == 'HEAD' || c.req.method == 'OPTIONS') {
       c.header('Content-Length', size.toString())
       c.status(200)

--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -84,6 +84,12 @@ const resolveByteRange = (spec: ByteRangeSpec, size: number): ByteRange | undefi
   return { start: spec.start, end }
 }
 
+// HTTP dates only have second precision, so compare at second granularity.
+const isNotModifiedSince = (ifModifiedSince: string, mtimeMs: number): boolean => {
+  const sinceMs = Date.parse(ifModifiedSince)
+  return !Number.isNaN(sinceMs) && Math.floor(mtimeMs / 1000) <= Math.floor(sinceMs / 1000)
+}
+
 type Decoder = (str: string) => string
 
 const tryDecode = (str: string, decoder: Decoder): string => {
@@ -190,24 +196,17 @@ export const serveStatic = <E extends Env = any>(
     const range = c.req.header('range') || ''
     c.header('Last-Modified', stats.mtime.toUTCString())
 
-    // Respond with 304 if the file has not been modified since the
-    // If-Modified-Since date. Per RFC 9110, If-Modified-Since is only used
-    // for GET/HEAD requests and is ignored when If-None-Match is present.
+    // RFC 9110: If-Modified-Since applies only to GET/HEAD requests and is
+    // ignored when If-None-Match is present.
     const ifModifiedSince = c.req.header('if-modified-since')
     if (
       ifModifiedSince &&
       !c.req.header('if-none-match') &&
-      (c.req.method === 'GET' || c.req.method === 'HEAD')
+      (c.req.method === 'GET' || c.req.method === 'HEAD') &&
+      isNotModifiedSince(ifModifiedSince, stats.mtimeMs)
     ) {
-      const sinceMs = Date.parse(ifModifiedSince)
-      // HTTP dates only have second precision, so compare at second granularity
-      if (
-        !Number.isNaN(sinceMs) &&
-        Math.floor(stats.mtimeMs / 1000) <= Math.floor(sinceMs / 1000)
-      ) {
-        await options.onFound?.(path, c)
-        return c.body(null, 304)
-      }
+      await options.onFound?.(path, c)
+      return c.body(null, 304)
     }
 
     if (c.req.method == 'HEAD' || c.req.method == 'OPTIONS') {

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -616,15 +616,18 @@ describe('Serve Static Middleware', () => {
     )
   })
   describe('If-Modified-Since', () => {
+    const plainTxtPath = path.join(__dirname, 'assets', 'static', 'plain.txt')
+    const zstPath = path.join(__dirname, 'assets', 'static-with-precompressed', 'hello.txt.zst')
+    const lastModified = (file: string) => statSync(file).mtime.toUTCString()
+
     it('Should return 304 when the file has not been modified since the date', async () => {
-      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
       const res = await requestServer(server, {
         method: 'GET',
         path: '/static/plain.txt',
-        headers: { 'if-modified-since': stats.mtime.toUTCString() },
+        headers: { 'if-modified-since': lastModified(plainTxtPath) },
       })
       expect(res.status).toBe(304)
-      expect(res.headers.get('last-modified')).toBe(stats.mtime.toUTCString())
+      expect(res.headers.get('last-modified')).toBe(lastModified(plainTxtPath))
       expect(res.headers.get('content-type')).toBe('text/plain; charset=utf-8')
       expect(res.headers.get('content-length')).toBeNull()
       expect(res.headers.get('content-range')).toBeNull()
@@ -632,25 +635,22 @@ describe('Serve Static Middleware', () => {
     })
 
     it('Should return 304 when the date is newer than the file mtime', async () => {
-      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const mtimeMs = statSync(plainTxtPath).mtimeMs
       const res = await requestServer(server, {
         method: 'GET',
         path: '/static/plain.txt',
-        headers: {
-          'if-modified-since': new Date(stats.mtimeMs + 60_000).toUTCString(),
-        },
+        headers: { 'if-modified-since': new Date(mtimeMs + 60_000).toUTCString() },
       })
       expect(res.status).toBe(304)
       expect(await res.text()).toBe('')
     })
 
     it('Should return 200 when the file mtime is newer than the date', async () => {
-      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
-      const lastModifiedMs = Math.floor(stats.mtimeMs / 1000) * 1000
+      const mtimeMs = Math.floor(statSync(plainTxtPath).mtimeMs / 1000) * 1000
       const res = await requestServer(server, {
         method: 'GET',
         path: '/static/plain.txt',
-        headers: { 'if-modified-since': new Date(lastModifiedMs - 1_000).toUTCString() },
+        headers: { 'if-modified-since': new Date(mtimeMs - 1_000).toUTCString() },
       })
       expect(res.status).toBe(200)
       expect(await res.text()).toBe('This is plain.txt')
@@ -667,13 +667,12 @@ describe('Serve Static Middleware', () => {
     })
 
     it('Should ignore If-Modified-Since when If-None-Match is present', async () => {
-      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
       const res = await requestServer(server, {
         method: 'GET',
         path: '/static/plain.txt',
         headers: {
           'if-none-match': '"v1"',
-          'if-modified-since': stats.mtime.toUTCString(),
+          'if-modified-since': lastModified(plainTxtPath),
         },
       })
       expect(res.status).toBe(200)
@@ -681,22 +680,20 @@ describe('Serve Static Middleware', () => {
     })
 
     it('Should return 304 for a HEAD request when not modified', async () => {
-      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
       const res = await requestServer(server, {
         method: 'HEAD',
         path: '/static/plain.txt',
-        headers: { 'if-modified-since': stats.mtime.toUTCString() },
+        headers: { 'if-modified-since': lastModified(plainTxtPath) },
       })
       expect(res.status).toBe(304)
       expect(res.body).toBeNull()
     })
 
     it('Should return 304 for a range request when not modified', async () => {
-      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
       const res = await requestServer(server, {
         method: 'GET',
         path: '/static/plain.txt',
-        headers: { range: '0-9', 'if-modified-since': stats.mtime.toUTCString() },
+        headers: { range: '0-9', 'if-modified-since': lastModified(plainTxtPath) },
       })
       expect(res.status).toBe(304)
       expect(res.headers.get('content-range')).toBeNull()
@@ -705,30 +702,26 @@ describe('Serve Static Middleware', () => {
     })
 
     it('Should return 304 for a precompressed response when not modified', async () => {
-      const stats = statSync(
-        path.join(__dirname, 'assets', 'static-with-precompressed', 'hello.txt.zst')
-      )
       const res = await requestServer(server, {
         method: 'GET',
         path: '/static-with-precompressed/hello.txt',
         headers: {
           'accept-encoding': 'zstd',
-          'if-modified-since': stats.mtime.toUTCString(),
+          'if-modified-since': lastModified(zstPath),
         },
       })
       expect(res.status).toBe(304)
       expect(res.headers.get('content-encoding')).toBe('zstd')
-      expect(res.headers.get('last-modified')).toBe(stats.mtime.toUTCString())
+      expect(res.headers.get('last-modified')).toBe(lastModified(zstPath))
       expect(res.headers.get('vary')).toBe('Accept-Encoding')
       expect(await res.text()).toBe('')
     })
 
     it('Should call onFound for a 304 response', async () => {
-      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
       const res = await requestServer(server, {
         method: 'GET',
         path: '/static/plain.txt',
-        headers: { 'if-modified-since': stats.mtime.toUTCString() },
+        headers: { 'if-modified-since': lastModified(plainTxtPath) },
       })
       expect(res.status).toBe(304)
       expect(res.headers.get('x-custom')).toContain('plain.txt')

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -615,6 +615,7 @@ describe('Serve Static Middleware', () => {
       }
     )
   })
+
   describe('If-Modified-Since', () => {
     const plainTxtPath = path.join(__dirname, 'assets', 'static', 'plain.txt')
     const zstPath = path.join(__dirname, 'assets', 'static-with-precompressed', 'hello.txt.zst')
@@ -628,7 +629,8 @@ describe('Serve Static Middleware', () => {
       })
       expect(res.status).toBe(304)
       expect(res.headers.get('last-modified')).toBe(lastModified(plainTxtPath))
-      expect(res.headers.get('content-type')).toBe('text/plain; charset=utf-8')
+      expect(res.headers.get('content-type')).toBeNull()
+      expect(res.headers.get('content-encoding')).toBeNull()
       expect(res.headers.get('content-length')).toBeNull()
       expect(res.headers.get('content-range')).toBeNull()
       expect(await res.text()).toBe('')
@@ -711,10 +713,34 @@ describe('Serve Static Middleware', () => {
         },
       })
       expect(res.status).toBe(304)
-      expect(res.headers.get('content-encoding')).toBe('zstd')
+      expect(res.headers.get('content-encoding')).toBeNull()
       expect(res.headers.get('last-modified')).toBe(lastModified(zstPath))
       expect(res.headers.get('vary')).toBe('Accept-Encoding')
       expect(await res.text()).toBe('')
+    })
+
+    it('Should ignore If-Modified-Since for a method other than GET/HEAD', async () => {
+      const res = await requestServer(server, {
+        method: 'POST',
+        path: '/static/plain.txt',
+        headers: { 'if-modified-since': lastModified(plainTxtPath) },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('This is plain.txt')
+    })
+
+    // RFC 9110 Section 13.1.3: a field value with more than one member is
+    // ignored. Node joins repeated headers into one comma-separated value.
+    it('Should ignore If-Modified-Since when the field value has more than one member', async () => {
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: {
+          'if-modified-since': `${lastModified(plainTxtPath)}, ${lastModified(plainTxtPath)}`,
+        },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('This is plain.txt')
     })
 
     it('Should call onFound for a 304 response', async () => {

--- a/test/serve-static.test.ts
+++ b/test/serve-static.test.ts
@@ -615,6 +615,125 @@ describe('Serve Static Middleware', () => {
       }
     )
   })
+  describe('If-Modified-Since', () => {
+    it('Should return 304 when the file has not been modified since the date', async () => {
+      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: { 'if-modified-since': stats.mtime.toUTCString() },
+      })
+      expect(res.status).toBe(304)
+      expect(res.headers.get('last-modified')).toBe(stats.mtime.toUTCString())
+      expect(res.headers.get('content-type')).toBe('text/plain; charset=utf-8')
+      expect(res.headers.get('content-length')).toBeNull()
+      expect(res.headers.get('content-range')).toBeNull()
+      expect(await res.text()).toBe('')
+    })
+
+    it('Should return 304 when the date is newer than the file mtime', async () => {
+      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: {
+          'if-modified-since': new Date(stats.mtimeMs + 60_000).toUTCString(),
+        },
+      })
+      expect(res.status).toBe(304)
+      expect(await res.text()).toBe('')
+    })
+
+    it('Should return 200 when the file mtime is newer than the date', async () => {
+      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const lastModifiedMs = Math.floor(stats.mtimeMs / 1000) * 1000
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: { 'if-modified-since': new Date(lastModifiedMs - 1_000).toUTCString() },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('This is plain.txt')
+    })
+
+    it('Should ignore an invalid If-Modified-Since header', async () => {
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: { 'if-modified-since': 'not-a-date' },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('This is plain.txt')
+    })
+
+    it('Should ignore If-Modified-Since when If-None-Match is present', async () => {
+      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: {
+          'if-none-match': '"v1"',
+          'if-modified-since': stats.mtime.toUTCString(),
+        },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('This is plain.txt')
+    })
+
+    it('Should return 304 for a HEAD request when not modified', async () => {
+      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const res = await requestServer(server, {
+        method: 'HEAD',
+        path: '/static/plain.txt',
+        headers: { 'if-modified-since': stats.mtime.toUTCString() },
+      })
+      expect(res.status).toBe(304)
+      expect(res.body).toBeNull()
+    })
+
+    it('Should return 304 for a range request when not modified', async () => {
+      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: { range: '0-9', 'if-modified-since': stats.mtime.toUTCString() },
+      })
+      expect(res.status).toBe(304)
+      expect(res.headers.get('content-range')).toBeNull()
+      expect(res.headers.get('accept-ranges')).toBeNull()
+      expect(await res.text()).toBe('')
+    })
+
+    it('Should return 304 for a precompressed response when not modified', async () => {
+      const stats = statSync(
+        path.join(__dirname, 'assets', 'static-with-precompressed', 'hello.txt.zst')
+      )
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static-with-precompressed/hello.txt',
+        headers: {
+          'accept-encoding': 'zstd',
+          'if-modified-since': stats.mtime.toUTCString(),
+        },
+      })
+      expect(res.status).toBe(304)
+      expect(res.headers.get('content-encoding')).toBe('zstd')
+      expect(res.headers.get('last-modified')).toBe(stats.mtime.toUTCString())
+      expect(res.headers.get('vary')).toBe('Accept-Encoding')
+      expect(await res.text()).toBe('')
+    })
+
+    it('Should call onFound for a 304 response', async () => {
+      const stats = statSync(path.join(__dirname, 'assets', 'static', 'plain.txt'))
+      const res = await requestServer(server, {
+        method: 'GET',
+        path: '/static/plain.txt',
+        headers: { 'if-modified-since': stats.mtime.toUTCString() },
+      })
+      expect(res.status).toBe(304)
+      expect(res.headers.get('x-custom')).toContain('plain.txt')
+    })
+  })
 })
 
 describe('Serve Static Middleware with wrong path', () => {


### PR DESCRIPTION
Fixes #189

`serveStatic` now evaluates `If-Modified-Since` per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-if-modified-since). `Last-Modified` is already set on every response, so this adds only the conditional check:

- Applies to `GET`/`HEAD` requests only
- Ignored when `If-None-Match` is present, as the latter takes precedence
- Ignored for a field value that is not a valid HTTP-date, or has more than one member
- Timestamps are compared at second granularity, since HTTP dates only have second precision; flooring both sides makes the `Last-Modified` -> `If-Modified-Since` round trip match exactly
- Responds `304 Not Modified` with an empty body when the file has not changed since the given date

The check runs after a file (or a precompressed variant, whose own `mtime` is used) has been found and before the response body is built, so a `304` skips `Content-Length`, `Accept-Ranges`, and `Content-Range` while still calling `onFound`. The comparison lives in a small `isNotModifiedSince` predicate so the handler reads as a single guard clause.

A `304` keeps `Last-Modified` and `Vary` but drops `Content-Type` and `Content-Encoding`, since a `304` cannot carry representation metadata ([Section 15.4.5](https://www.rfc-editor.org/rfc/rfc9110#section-15.4.5)). `Vary` is retained so caches still know which precompressed representation was selected. This mirrors `removeContentHeaderFields()` in `send`, used by Express' `serve-static`.

11 tests cover a `304` on an exact and on a later date, `200` on an earlier date, an invalid header, `If-None-Match` precedence, a non-`GET`/`HEAD` method, a field value with more than one member, `HEAD`, range requests, precompressed variants, and `onFound`. All of `format`, `lint`, `typecheck`, `test`, and `build` + `publint` pass locally.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm run format:fix && pnpm run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about/getting-started) to document the code
